### PR TITLE
Update defining_ant_metadata.rst

### DIFF
--- a/docs/defining_ant_metadata.rst
+++ b/docs/defining_ant_metadata.rst
@@ -64,16 +64,16 @@ Capsule are defined in the ant reference frame.
    bodyID = e$createAntShapeType("body")
 
 
-   a$addCapsule(headID,fmCapsule(c1 = c(1,2), c2 = (3,4), r1 = 0.5, r2 = 1.0 ))
-   a$addCapsule(antennaID,fmCapsule(c1 = c(1,2), c2 = (3,4), r1 = 0.5, r2 = 1.0 ))
-   a$addCapsule(antennaID,fmCapsule(c1 = c(1,2), c2 = (3,4), r1 = 0.5, r2 = 1.0 ))
-   a$addCapsule(bodyID,fmCapsule(c1 = c(1,2), c2 = (3,4), r1 = 0.5, r2 = 1.0 ))
-   a$addCapsule(bodyID,fmCapsule(c1 = c(1,2), c2 = (3,4), r1 = 0.5, r2 = 1.0 ))
+   a$addCapsule(headID,fmCapsuleCreate(c1 = c(1,2), c2 = c(3,4), r1 = 0.5, r2 = 1.0 ))
+   a$addCapsule(antennaID,fmCapsuleCreate(c1 = c(1,2), c2 = c(3,4), r1 = 0.5, r2 = 1.0 ))
+   a$addCapsule(antennaID,fmCapsuleCreate(c1 = c(1,2), c2 = c(3,4), r1 = 0.5, r2 = 1.0 ))
+   a$addCapsule(bodyID,fmCapsuleCreate(c1 = c(1,2), c2 = c(3,4), r1 = 0.5, r2 = 1.0 ))
+   a$addCapsule(bodyID,fmCapsuleCreate(c1 = c(1,2), c2 = c(3,4), r1 = 0.5, r2 = 1.0 ))
 
-   a$capsules # a data.frame with all capsules data
+   a$capsules # a list with all capsules data
 
    for ( typedCapsule in a$capsules ) {
-       print(typedCapsule$type,typedCapsule$capsule)
+       print(paste(typedCapsule$type,capture.output(typedCapsule$capsule)))
    }
 
 


### PR DESCRIPTION
L67-71:
(1) There was a c missing in the capsule definition ( c2 = c(3,4) instead of  c2 = (3,4))
(2) 'a$addCapsule(headID,fmCapsuleCreate(c1 = c(1,2), c2 = c(3,4), r1 = 0.5, r2 = 1.0 ))' throws error "Error in fmCapsule(c1 = c(1, 2), c2 = c(3, 4), r1 = 0.5, r2 = 1) : could not find function "fmCapsule""
but 'a$addCapsule(headID,fmCapsuleCreate(c1 = c(1,2), c2 = c(3,4), r1 = 0.5, r2 = 1.0 )' works

Line 76: 
'print(typedCapsule$type,typedCapsule$capsule)' "throws error "Error in print.default(typedCapsule$type, typedCapsule$capsule) :   invalid printing digits -2147483648"
but 
'print(paste(typedCapsule$type,capture.output(typedCapsule$capsule)))' works (though not very elegant output)