### PR TITLE
Allows ant metadata inter-individual match in interactions.

### DIFF
--- a/bindings/python/src/Matchers.cpp
+++ b/bindings/python/src/Matchers.cpp
@@ -93,8 +93,9 @@ the Ant meets the criterion.
 
 Args:
     key (str): the key to match from
-    value (str): the value for key. Should be a bool, int, float, str
-        or :class:`Time`
+    value (bool|int|float|str|fort_myrmidon.Time|None): the value for key. If
+        none is passed, it will only works on interaction, and make sure the two
+        individuals value for key are the same values.
 
 Returns:
     Matcher: a Matcher that matches Ant who current **key** meta data

--- a/src/fort/myrmidon/Matchers.cpp
+++ b/src/fort/myrmidon/Matchers.cpp
@@ -8,14 +8,18 @@ namespace myrmidon {
 Matcher::Ptr Matcher::And(std::vector<Ptr> matchers) {
 	std::vector<PPtr> pMatchers;
 	pMatchers.reserve(matchers.size());
-	for ( const auto & m : matchers ) { pMatchers.push_back(m->d_p); }
+	for (const auto &m : matchers) {
+		pMatchers.push_back(m->d_p);
+	}
 	return Matcher::Ptr(new Matcher(priv::Matcher::And(pMatchers)));
 }
 
 Matcher::Ptr Matcher::Or(std::vector<Ptr> matchers) {
 	std::vector<PPtr> pMatchers;
 	pMatchers.reserve(matchers.size());
-	for ( const auto & m : matchers ) { pMatchers.push_back(m->d_p); }
+	for (const auto &m : matchers) {
+		pMatchers.push_back(m->d_p);
+	}
 	return Matcher::Ptr(new Matcher(priv::Matcher::Or(pMatchers)));
 }
 
@@ -23,17 +27,23 @@ Matcher::Ptr Matcher::AntID(fort::myrmidon::AntID ID) {
 	return Matcher::Ptr(new Matcher(priv::Matcher::AntIDMatcher(ID)));
 }
 
-Matcher::Ptr Matcher::AntMetaData(const std::string & key,
-                                  const Value & value) {
-	return Matcher::Ptr(new Matcher(priv::Matcher::AntColumnMatcher(key,value)));
+Matcher::Ptr Matcher::AntMetaData(
+    const std::string &key, const std::optional<Value> &value
+) {
+	return Matcher::Ptr(new Matcher(priv::Matcher::AntColumnMatcher(key, value))
+	);
 }
 
 Matcher::Ptr Matcher::AntDistanceSmallerThan(double distance) {
-	return Matcher::Ptr(new Matcher(priv::Matcher::AntDistanceSmallerThan(distance)));
+	return Matcher::Ptr(
+	    new Matcher(priv::Matcher::AntDistanceSmallerThan(distance))
+	);
 }
 
 Matcher::Ptr Matcher::AntDistanceGreaterThan(double distance) {
-	return Matcher::Ptr(new Matcher(priv::Matcher::AntDistanceGreaterThan(distance)));
+	return Matcher::Ptr(
+	    new Matcher(priv::Matcher::AntDistanceGreaterThan(distance))
+	);
 }
 
 Matcher::Ptr Matcher::AntAngleGreaterThan(double angle) {
@@ -44,24 +54,24 @@ Matcher::Ptr Matcher::AntAngleSmallerThan(double angle) {
 	return Matcher::Ptr(new Matcher(priv::Matcher::AntAngleSmallerThan(angle)));
 }
 
-Matcher::Ptr Matcher::InteractionType(AntShapeTypeID type1,
-                                      AntShapeTypeID type2) {
-	return Matcher::Ptr(new Matcher(priv::Matcher::InteractionType(type1,type2)));
+Matcher::Ptr
+Matcher::InteractionType(AntShapeTypeID type1, AntShapeTypeID type2) {
+	return Matcher::Ptr(new Matcher(priv::Matcher::InteractionType(type1, type2)
+	));
 }
 
-Matcher::Ptr Matcher::AntDisplacement(double under,
-                                      Duration minimumGap) {
+Matcher::Ptr Matcher::AntDisplacement(double under, Duration minimumGap) {
 
-	return Matcher::Ptr(new Matcher(priv::Matcher::AntDisplacement(under,minimumGap)));
+	return Matcher::Ptr(
+	    new Matcher(priv::Matcher::AntDisplacement(under, minimumGap))
+	);
 }
-
 
 Matcher::PPtr Matcher::ToPrivate() const {
 	return d_p;
 }
 
-std::ostream & operator<<(std::ostream & out,
-                          const fort::myrmidon::Matcher & m) {
+std::ostream &operator<<(std::ostream &out, const fort::myrmidon::Matcher &m) {
 	return out << *m.d_p;
 }
 

--- a/src/fort/myrmidon/Matchers.hpp
+++ b/src/fort/myrmidon/Matchers.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <memory>
-#include <vector>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include <fort/time/Time.hpp>
 
 #include <fort/myrmidon/types/Typedefs.hpp>
 #include <fort/myrmidon/types/Value.hpp>
-
 
 namespace fort {
 namespace myrmidon {
@@ -21,12 +21,10 @@ class Matcher;
  *
  * @return a reference to out
  */
-std::ostream & operator<<(std::ostream & out,
-                          const fort::myrmidon::Matcher & m);
+std::ostream &operator<<(std::ostream &out, const fort::myrmidon::Matcher &m);
 
-}
-}
-
+} // namespace myrmidon
+} // namespace fort
 
 namespace fort {
 namespace myrmidon {
@@ -53,8 +51,8 @@ class Query;
  *
  *  * AntID() : one of the considered Ant in the result should
  *    match a given AntID
- *  * AntMetaData() : one of the key-value user defined meta-data pair
- *    for one of the Ant should match.
+ *  * AntMetaData() : one of the key-value user defined meta-data pair for one
+ *    of the Ant should match, or the two value should match for the two ants.
  *  * AntDistanceSmallerThan(),AntDistanceGreaterThan() : for
  *    interaction queries only, ensure some criterion for the distance
  *    between the two considedred Ant.
@@ -90,7 +88,7 @@ public:
 	 * @return a new Matcher which will match only when all matchers
 	 *         also matches.
 	 */
-	static Ptr And(std::vector<Ptr> matchers);
+	static Ptr                       And(std::vector<Ptr> matchers);
 
 	/**
 	 * Combines several Matcher together in disjunction.
@@ -118,14 +116,16 @@ public:
 	 *  Matches a given user meta data key/value
 	 *
 	 * @param key the key to match against
-	 * @param value the value to match against
+	 * @param value the value to match against, or None
 	 *
-	 * In case of interactions, matches any interaction with one of
-	 * the Ant meeting the criterion.
+	 * In case of interactions, is value is std::nullopt, matches any
+	 * interaction with the two ants having the same key value. Otherwise
+	 * matches if one of the two ants value matches.
 	 *
 	 * @return a Matcher that matches Ant with key is value.
 	 */
-	static Ptr AntMetaData(const std::string & key, const Value & value);
+	static Ptr
+	AntMetaData(const std::string &key, const std::optional<Value> &value);
 
 	/**
 	 * Matches a distance between two Ants
@@ -175,7 +175,6 @@ public:
 	 */
 	static Ptr AntAngleGreaterThan(double angle);
 
-
 	/**
 	 * Matches an InteractionType
 	 *
@@ -189,8 +188,6 @@ public:
 	 *         opposite.
 	 */
 	static Ptr InteractionType(AntShapeTypeID type1, AntShapeTypeID type2);
-
-
 
 	/**
 	 * Matches Ant displacement
@@ -207,29 +204,26 @@ public:
 	 * @return a Matcher that reject large displacements in a tracking
 	 *         gap.
 	 */
-	static Ptr AntDisplacement(double under , Duration minimumGap);
-
+	static Ptr AntDisplacement(double under, Duration minimumGap);
 
 private:
 	friend class Query;
 	friend class fort::myrmidon::priv::Query;
 	friend class PublicMatchersUTest_RightMatcher_Test;
 
-	friend std::ostream & operator<<(std::ostream & out,
-	                                 const fort::myrmidon::Matcher & m);
+	friend std::ostream &
+	operator<<(std::ostream &out, const fort::myrmidon::Matcher &m);
 
 	// opaque pointer to implementation
 	typedef std::shared_ptr<priv::Matcher> PPtr;
-
 
 	// Private implementation constructor
 	// @pMatcher opaque pointer to implementation
 	//
 	// User should not build a matcher directly, they must use this
 	// class static methods instead.
-	inline Matcher(const PPtr & pMatcher)
-		: d_p(pMatcher) {
-	}
+	inline Matcher(const PPtr &pMatcher)
+	    : d_p(pMatcher) {}
 
 	// Cast to opaque implementation
 	//
@@ -238,7 +232,6 @@ private:
 
 	PPtr d_p;
 };
-
 
 } // namespace myrmidon
 } // namespace fortoio

--- a/src/fort/myrmidon/priv/Matchers.hpp
+++ b/src/fort/myrmidon/priv/Matchers.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <vector>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include <fort/time/Time.hpp>
 
-#include <fort/myrmidon/types/Typedefs.hpp>
 #include <fort/myrmidon/types/Collision.hpp>
+#include <fort/myrmidon/types/Typedefs.hpp>
 #include <fort/myrmidon/types/Value.hpp>
 
 #include "ForwardDeclaration.hpp"
-
 
 namespace fort {
 namespace myrmidon {
@@ -20,13 +20,15 @@ class Matcher {
 public:
 	typedef std::shared_ptr<Matcher> Ptr;
 
-	static Ptr And(const std::vector<Ptr> & matcher);
+	static Ptr And(const std::vector<Ptr> &matcher);
 
-	static Ptr Or(const std::vector<Ptr> & matcher);
+	static Ptr Or(const std::vector<Ptr> &matcher);
 
 	static Ptr AntIDMatcher(AntID ID);
 
-	static Ptr AntColumnMatcher(const std::string & name, const Value & value);
+	static Ptr AntColumnMatcher(
+	    const std::string &name, const std::optional<Value> &value
+	);
 
 	static Ptr AntDistanceSmallerThan(double distance);
 
@@ -36,29 +38,31 @@ public:
 
 	static Ptr AntAngleSmallerThan(double angle);
 
-	static Ptr InteractionType(AntShapeTypeID type1,
-	                           AntShapeTypeID type2);
+	static Ptr InteractionType(AntShapeTypeID type1, AntShapeTypeID type2);
 
-	static Ptr AntDisplacement(double under,
-	                           Duration minimumGap);
+	static Ptr AntDisplacement(double under, Duration minimumGap);
 
-	virtual void SetUpOnce(const priv::AntByID & ants) = 0;
+	virtual void SetUpOnce(const priv::AntByID &ants) = 0;
 
-	virtual uint8_t Depth() const { return 1; };
+	virtual uint8_t Depth() const {
+		return 1;
+	};
 
+	virtual void SetUp(const IdentifiedFrame &identifiedFrame) = 0;
 
-	virtual void SetUp(const IdentifiedFrame & identifiedFrame) = 0;
+	virtual uint64_t Match(
+	    fort::myrmidon::AntID                   ant1,
+	    fort::myrmidon::AntID                   ant2,
+	    const fort::myrmidon::InteractionTypes &types
+	) = 0;
 
-	virtual uint64_t Match(fort::myrmidon::AntID ant1,
-	                       fort::myrmidon::AntID ant2,
-	                       const fort::myrmidon::InteractionTypes & types) = 0;
-
-	virtual void Format(std::ostream & out) const = 0;
+	virtual void Format(std::ostream &out) const = 0;
 
 	virtual ~Matcher();
 };
 
-std::ostream & operator<<(std::ostream & out, const fort::myrmidon::priv::Matcher & m);
+std::ostream &
+operator<<(std::ostream &out, const fort::myrmidon::priv::Matcher &m);
 
 } // namespace priv
 } // namespace myrmidon


### PR DESCRIPTION
By passing `None` or `std::nullopt` to `Matcher.AntMetadata`, it will now match when two individual have the same value.
