### PR TITLE
[python] Improves representations of binded object in ipython (jupyter notebooks)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ proposes python with **formicidae-tracker-myrmidon** package.  packages.
 editing of **.myrmidon** files, and to provide basic visualization of
 tracking datasets.
 
-INstallation
+Installation
 ------------
 
 **fort-myrmidon** and all the supported python bindings (python) are primarly

--- a/bindings/python/src/Ant.cpp
+++ b/bindings/python/src/Ant.cpp
@@ -2,15 +2,16 @@
 
 #include <fort/myrmidon/Ant.hpp>
 #include <fort/myrmidon/Identification.hpp>
+#include <sstream>
 
 namespace py = pybind11;
 
-
-void BindAnt(py::module_ & m) {
+void BindAnt(py::module_ &m) {
 	using namespace fort::myrmidon;
-	py::class_<Ant,Ant::Ptr> ant(m,
-	                             "Ant",
-	                             R"pydoc(
+	py::class_<Ant, Ant::Ptr> ant(
+	    m,
+	    "Ant",
+	    R"pydoc(
 
 Ant are the main object of interest of an :class:`Experiment`. They
 are identified from tags with :class:`Identification`, have a virtual
@@ -45,34 +46,49 @@ Ant can stores timed user defined metadata. These are modifiable
 using :meth:`SetValue` and :meth:`DeleteValue` and accesible through
 :meth:`GetValue`.
 
-)pydoc");
+)pydoc"
+	);
 
-	py::enum_<Ant::DisplayState>(ant,
-	                             "DisplayState",
-	                             "Enumerates the possible display state for an Ant")
-		.value("VISIBLE",Ant::DisplayState::VISIBLE,"the Ant is visible")
-		.value("HIDDEN",Ant::DisplayState::HIDDEN,"the Ant is hidden")
-		.value("SOLO",Ant::DisplayState::SOLO,"the Ant is visible and all other non-solo ant are hidden");
+	py::enum_<Ant::DisplayState>(
+	    ant,
+	    "DisplayState",
+	    "Enumerates the possible display state for an Ant"
+	)
+	    .value("VISIBLE", Ant::DisplayState::VISIBLE, "the Ant is visible")
+	    .value("HIDDEN", Ant::DisplayState::HIDDEN, "the Ant is hidden")
+	    .value(
+	        "SOLO",
+	        Ant::DisplayState::SOLO,
+	        "the Ant is visible and all other non-solo ant are hidden"
+	    );
 
-
-	ant.def_property_readonly("Identifications",
-		                       &Ant::Identifications,
-	                          "List[Identification]: all Identification that target this Ant, ordered by validity time.")
-		.def_property_readonly("ID",
-		                       &Ant::ID,
-		                       "int: the AntID for this Ant")
-		.def_property("DisplayColor",
-		              &Ant::DisplayColor,
-		              &Ant::SetDisplayColor,
-		              "Tuple[int,int,int]: the color used to display the Ant in **fort-studio**")
-		.def_property("DisplayStatus",
-		              &Ant::DisplayStatus,
-		              &Ant::SetDisplayStatus,
-		              "Ant.DisplayState: the DisplayState in **fort-studio** for this Ant")
-		.def_property_readonly("Capsules",
-		                       &Ant::Capsules,
-		                       "List[Tuple[int,Capsule]]: a list of capsules and their type")
-		.def("IdentifiedAt",
+	ant.def_property_readonly(
+	       "Identifications",
+	       &Ant::Identifications,
+	       "List[Identification]: all Identification that target this Ant, "
+	       "ordered by validity time."
+	)
+	    .def_property_readonly("ID", &Ant::ID, "int: the AntID for this Ant")
+	    .def_property(
+	        "DisplayColor",
+	        &Ant::DisplayColor,
+	        &Ant::SetDisplayColor,
+	        "Tuple[int,int,int]: the color used to display the Ant in "
+	        "**fort-studio**"
+	    )
+	    .def_property(
+	        "DisplayStatus",
+	        &Ant::DisplayStatus,
+	        &Ant::SetDisplayStatus,
+	        "Ant.DisplayState: the DisplayState in **fort-studio** for this Ant"
+	    )
+	    .def_property_readonly(
+	        "Capsules",
+	        &Ant::Capsules,
+	        "List[Tuple[int,Capsule]]: a list of capsules and their type"
+	    )
+	    .def(
+	        "IdentifiedAt",
 	        &Ant::IdentifiedAt,
 	        py::arg("time"),
 	        R"pydoc(
@@ -86,12 +102,14 @@ Returns:
 
 Raises:
     Error: if no tag identifies this Ant at **time**.
-)pydoc")
-		.def("GetValue",
-		     &Ant::GetValue,
-		     py::arg("key"),
-		     py::arg("time"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "GetValue",
+	        &Ant::GetValue,
+	        py::arg("key"),
+	        py::arg("time"),
+	        R"pydoc(
 Gets user defined timed metadata.
 
 Args:
@@ -104,16 +122,23 @@ Returns:
 
 Raises:
     IndexError: if **key** is not defined in :class:`Experiment`
-)pydoc")
-		.def("GetValues",
-		     [](const Ant & self, const std::string & key) -> std::vector<std::pair<fort::Time,Value>> {
-			     std::vector<std::pair<fort::Time,Value>> res;
-			     const auto & values = self.GetValues(key);
-			     std::copy(values.begin(),values.end(),std::back_inserter(res));
-			     return res;
-		     },
-		     py::arg("key"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "GetValues",
+	        [](const Ant &self, const std::string &key
+	        ) -> std::vector<std::pair<fort::Time, Value>> {
+		        std::vector<std::pair<fort::Time, Value>> res;
+		        const auto &values = self.GetValues(key);
+		        std::copy(
+		            values.begin(),
+		            values.end(),
+		            std::back_inserter(res)
+		        );
+		        return res;
+	        },
+	        py::arg("key"),
+	        R"pydoc(
 Gets metadata key changes over time.
 
 Args:
@@ -121,13 +146,15 @@ Args:
 
 Raises:
     IndexError: if **key** is not defined in :class:`Experiment`
-)pydoc")
-		.def("SetValue",
-		     &Ant::SetValue,
-		     py::arg("key"),
-		     py::arg("value"),
-		     py::arg("time"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "SetValue",
+	        &Ant::SetValue,
+	        py::arg("key"),
+	        py::arg("value"),
+	        py::arg("time"),
+	        R"pydoc(
 Sets a user defined timed metadata
 
 Args:
@@ -141,12 +168,14 @@ Raises:
     IndexError: if **key** is not defined in the :class:`Experiment`
     ValueError: if **time** is :meth:`Time.Forever`
     RuntimeError: if **value** is not of the right type for **key**
-)pydoc")
-		.def("DeleteValue",
-		     &Ant::DeleteValue,
-		     py::arg("key"),
-		     py::arg("time"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "DeleteValue",
+	        &Ant::DeleteValue,
+	        py::arg("key"),
+	        py::arg("time"),
+	        R"pydoc(
 Clears a user defined timed metadata.
 
 Args:
@@ -156,12 +185,14 @@ Args:
 Raises:
     IndexError: if **key** was not previously set for **time** with
         :meth:`SetValue`.
-)pydoc")
-		.def("AddCapsule",
-		     &Ant::AddCapsule,
-		     py::arg("shapeTypeID"),
-		     py::arg("capsule"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "AddCapsule",
+	        &Ant::AddCapsule,
+	        py::arg("shapeTypeID"),
+	        py::arg("capsule"),
+	        R"pydoc(
 Adds a Capsule to the Ant virtual shape.
 
 Args:
@@ -171,11 +202,13 @@ Args:
 Raises:
     ValueError: if **shapeTypeID** is not defined in the
         :class:`Experiment`
-)pydoc")
-		.def("DeleteCapsule",
-		     &Ant::DeleteCapsule,
-		     py::arg("index"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "DeleteCapsule",
+	        &Ant::DeleteCapsule,
+	        py::arg("index"),
+	        R"pydoc(
 Removes one of the shape
 
 Args:
@@ -183,12 +216,26 @@ Args:
 
 Raises:
     IndexError: if ``index >= len(self.Capsules())``
-)pydoc")
-		.def("ClearCapsules",
-		     &Ant::ClearCapsules,
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "ClearCapsules",
+	        &Ant::ClearCapsules,
+	        R"pydoc(
 Removes all capsules for this Ant.
-)pydoc")
-		;
-
+)pydoc"
+	    )
+	    .def(
+	        "__str__",
+	        [](const Ant &a) -> std::string {
+		        std::ostringstream oss;
+		        oss << a;
+		        return oss.str();
+	        }
+	    )
+	    .def("__repr__", [](const Ant &a) -> std::string {
+		    std::ostringstream oss;
+		    oss << a;
+		    return oss.str();
+	    });
 }

--- a/bindings/python/src/Identification.cpp
+++ b/bindings/python/src/Identification.cpp
@@ -4,11 +4,12 @@
 
 namespace py = pybind11;
 
-void BindIdentification(py::module_ & m) {
+void BindIdentification(py::module_ &m) {
 	using namespace fort::myrmidon;
-	py::class_<Identification,Identification::Ptr>(m,
-	                                               "Identification",
-	                                               R"pydoc(
+	py::class_<Identification, Identification::Ptr>(
+	    m,
+	    "Identification",
+	    R"pydoc(
 Identifications relates tag to :class:`Ant` with :class:`Time` and geometric
 data.
 
@@ -58,58 +59,86 @@ Attributes:
     DEFAULT_TAG_SIZE (float): a value of ``0.0`` that indicates that the
         :attr:`Experiment.DefaultTagSize` should be used.
 
-)pydoc")
-		.def_readonly_static("DEFAULT_TAG_SIZE",
-		                     &Identification::DEFAULT_TAG_SIZE,
-		                     "float: a value that marks the Identification to use Experiment.DefaultTagSize")
-		.def_property_readonly("TagValue",
-		                       &Identification::TagValue,
-		                       "int: the associated TagID of this identification")
-		.def_property_readonly("TargetAntID",
-		                       &Identification::TargetAntID,
-		                       "int: the associated AntID of this identification")
-		.def_property_readonly("AntPosition",
-		                       &Identification::AntPosition,
-		                       ":obj:`numpy.ndarray`: Ant center position relative to the tag center. (float64, size[2,1])")
-		.def_property_readonly("AntAngle",
-		                       &Identification::AntAngle,
-		                       "float: orientation difference between the ant orientation and its physical tag, expressed in radians.")
-		.def_property("Start",
-		              &Identification::Start,
-		              &Identification::SetStart,
-		              "Time: the first valid Time fort this identification, it can be :meth:`Time.SinceEver`")
-		.def_property("End",
-		              &Identification::End,
-		              &Identification::SetEnd,
-		              "Time: the first invalid Time fort this identification, it can be :meth:`Time.Forever`")
-		.def_property("TagSize",
-		              &Identification::TagSize,
-		              &Identification::SetTagSize,
-		              "float: the Identification tag size in millimeters, could be :attr:`DEFAULT_TAG_SIZE` to use :attr:`Experiment.DefaultTagSize`")
-		.def("HasDefaultTagSize",
-		     &Identification::HasDefaultTagSize,
-		     R"pydoc(
+)pydoc"
+	)
+	    .def_readonly_static(
+	        "DEFAULT_TAG_SIZE",
+	        &Identification::DEFAULT_TAG_SIZE,
+	        "float: a value that marks the Identification to use "
+	        "Experiment.DefaultTagSize"
+	    )
+	    .def_property_readonly(
+	        "TagValue",
+	        &Identification::TagValue,
+	        "int: the associated TagID of this identification"
+	    )
+	    .def_property_readonly(
+	        "TargetAntID",
+	        &Identification::TargetAntID,
+	        "int: the associated AntID of this identification"
+	    )
+	    .def_property_readonly(
+	        "AntPosition",
+	        &Identification::AntPosition,
+	        ":obj:`numpy.ndarray`: Ant center position relative to the tag "
+	        "center. (float64, size[2,1])"
+	    )
+	    .def_property_readonly(
+	        "AntAngle",
+	        &Identification::AntAngle,
+	        "float: orientation difference between the ant orientation and its "
+	        "physical tag, expressed in radians."
+	    )
+	    .def_property(
+	        "Start",
+	        &Identification::Start,
+	        &Identification::SetStart,
+	        "Time: the first valid Time fort this identification, it can be "
+	        ":meth:`Time.SinceEver`"
+	    )
+	    .def_property(
+	        "End",
+	        &Identification::End,
+	        &Identification::SetEnd,
+	        "Time: the first invalid Time fort this identification, it can be "
+	        ":meth:`Time.Forever`"
+	    )
+	    .def_property(
+	        "TagSize",
+	        &Identification::TagSize,
+	        &Identification::SetTagSize,
+	        "float: the Identification tag size in millimeters, could be "
+	        ":attr:`DEFAULT_TAG_SIZE` to use :attr:`Experiment.DefaultTagSize`"
+	    )
+	    .def(
+	        "HasDefaultTagSize",
+	        &Identification::HasDefaultTagSize,
+	        R"pydoc(
 Indicates if the :attr:`Experiment.DefaultTagSize` is used
 
 Returns:
     bool: ``True`` if this Identification uses
     :attr:`Experiment.DefaultTagSize`, i.e. when :attr:`TagSize` ==
     :attr:`DEFAULT_TAG_SIZE`
-)pydoc")
-		.def("HasUserDefinedAntPose",
-		     &Identification::HasUserDefinedAntPose,
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "HasUserDefinedAntPose",
+	        &Identification::HasUserDefinedAntPose,
+	        R"pydoc(
 Indicates if the user overrided the computed pose.
 
 Returns:
     bool: ``True`` if the ant position relatively to the tag has
     been set by the user.
-)pydoc")
-		.def("SetUserDefinedAntPose",
-		     &Identification::SetUserDefinedAntPose,
-		     py::arg("antPosition"),
-		     py::arg("antAngle"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "SetUserDefinedAntPose",
+	        &Identification::SetUserDefinedAntPose,
+	        py::arg("antPosition"),
+	        py::arg("antAngle"),
+	        R"pydoc(
 Sets an user defined ant position relatively to the tag, overiding
 the one computed from manual measurements.
 
@@ -122,19 +151,35 @@ Args:
         reference frame
     antAngle (float): the ant angle relatively to the tag angle,
         in radians
-)pydoc")
-		.def("ClearUserDefinedAntPose",
-		     &Identification::ClearUserDefinedAntPose,
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "ClearUserDefinedAntPose",
+	        &Identification::ClearUserDefinedAntPose,
+	        R"pydoc(
 Removes any user-defined ant-tag relative geometry data and re-enable
 the one computed from manual measurement made in **fort-studio**.
-)pydoc")
-		.def("__str__",[](const Identification::Ptr & i) -> std::string {
-			               std::ostringstream oss;
-			               oss << *i;
-			               return oss.str();
-		               });
-		;
+)pydoc"
+	    )
+	    .def(
+	        "__str__",
+	        [](const Identification::Ptr &i) -> std::string {
+		        std::ostringstream oss;
+		        oss << *i;
+		        return oss.str();
+	        }
+	    )
+	    .def("__repr__", [](const Identification::Ptr &i) -> std::string {
+		    std::ostringstream oss;
+		    oss << *i;
+		    return oss.str();
+	    });
 
-		py::register_exception<OverlappingIdentification>(m,"OverlappingIdentification",PyExc_RuntimeError);
+	;
+
+	py::register_exception<OverlappingIdentification>(
+	    m,
+	    "OverlappingIdentification",
+	    PyExc_RuntimeError
+	);
 }

--- a/bindings/python/src/Matchers.cpp
+++ b/bindings/python/src/Matchers.cpp
@@ -247,5 +247,13 @@ Returns:
 		        oss << *m;
 		        return oss.str();
 	        }
+	    )
+	    .def(
+	        "__repr__",
+	        [](const fort::myrmidon::Matcher::Ptr &m) -> std::string {
+		        std::ostringstream oss;
+		        oss << *m;
+		        return oss.str();
+	        }
 	    );
 };

--- a/bindings/python/src/Shapes.cpp
+++ b/bindings/python/src/Shapes.cpp
@@ -1,5 +1,6 @@
 #include "BindTypes.hpp"
 #include <pybind11/stl_bind.h>
+#include <sstream>
 
 namespace py = pybind11;
 
@@ -12,11 +13,14 @@ void BindShapes(py::module_ &m) {
 A Generic class for a Shape
 )pydoc"
 	);
-	shape.def_property_readonly(
-	    "ShapeType",
-	    &Shape::ShapeType,
-	    "(fort_myrmidon.Shape.Type): the type of the shape"
-	);
+	shape
+	    .def_property_readonly(
+	        "ShapeType",
+	        &Shape::ShapeType,
+	        "(fort_myrmidon.Shape.Type): the type of the shape"
+	    )
+	    .def("__str__", [](const Shape::Ptr &ptr) { return ptr->Format(); })
+	    .def("__repr__", [](const Shape::Ptr &ptr) { return ptr->Format(); });
 
 	py::enum_<Shape::Type>(shape, "Type", "Enum for the type of a Shape")
 	    .value("CIRCLE", Shape::Type::CIRCLE, "int: a circle")

--- a/bindings/python/src/Space.cpp
+++ b/bindings/python/src/Space.cpp
@@ -86,5 +86,7 @@ Within a single Space , it could be relevant to define
     Raises:
         IndexError: if time is outside of this Space tracking data
 )pydoc"
-	    );
+	    )
+	    .def("__str__", [](const Space::Ptr &s) { return s->Format(); })
+	    .def("__repr__", [](const Space::Ptr &s) { return s->Format(); });
 }

--- a/bindings/python/src/TrackingSolver.cpp
+++ b/bindings/python/src/TrackingSolver.cpp
@@ -1,16 +1,21 @@
 #include "BindMethods.hpp"
 
 #include <fort/myrmidon/TrackingSolver.hpp>
+#include <fort/myrmidon/types/IdentifiedFrame.hpp>
 
-fort::myrmidon::IdentifiedFrame::Ptr
-TrackingSolverIdentifyFrame(const fort::myrmidon::TrackingSolver & self,
-                                 const py::object & frame_readout,
-                                 fort::myrmidon::SpaceID spaceID) {
-	std::string serialized = frame_readout.attr("SerializeToString")().cast<std::string>();
+fort::myrmidon::IdentifiedFrame::Ptr TrackingSolverIdentifyFrame(
+    const fort::myrmidon::TrackingSolver &self,
+    const py::object                     &frame_readout,
+    fort::myrmidon::SpaceID               spaceID,
+    size_t                                zoneDepth,
+    fort::myrmidon::ZonePriority          zoneOrder
+) {
+	std::string serialized =
+	    frame_readout.attr("SerializeToString")().cast<std::string>();
 	fort::hermes::FrameReadout ro;
 	ro.ParseFromString(serialized);
 	auto res = std::make_shared<fort::myrmidon::IdentifiedFrame>();
-	self.IdentifyFrame(*res,ro,spaceID);
+	self.IdentifyFrame(*res, ro, spaceID, zoneDepth, zoneOrder);
 	return res;
 }
 
@@ -45,12 +50,18 @@ void BindTrackingSolver(py::module_ &m) {
 	        &TrackingSolverIdentifyFrame,
 	        py::arg("frameReadout"),
 	        py::arg("spaceID"),
+	        py::arg("zoneDepth") = 1,
+	        py::arg("zoneOrder") =
+	            fort::myrmidon::ZonePriority::PREDECENCE_LOWER,
 	        R"pydoc(
     Identifies Ant in a raw frame readout
 
     Args:
         frame (py_fort_hermes.FrameReadout): the raw data to identify
         spaceID (int): the SpaceID associated with frame
+        zoneDepth (int): the maximal number of zone to compute.
+        zoneOrder(fort_myrmidon.ZonePriority): specifies if lower zone ID takes
+            predecence over higher zoneID (default) or the opposite.
 
     Returns:
 

--- a/bindings/python/src/Types.cpp
+++ b/bindings/python/src/Types.cpp
@@ -327,29 +327,41 @@ void BindExperimentDataInfo(py::module_ & m) {
 		;
 }
 
-void BindTypes(py::module_ & m) {
+void BindTypes(py::module_ &m) {
 	BindTime(m);
 
 	using namespace fort::myrmidon;
-	py::class_<Value>(m,"Value")
-		.def(py::init<bool>())
-		.def(py::init<int>())
-		.def(py::init<double>())
-		.def(py::init<std::string>())
-		.def(py::init<fort::Time>())
-		;
-	py::implicitly_convertible<bool,Value>();
-	py::implicitly_convertible<int,Value>();
-	py::implicitly_convertible<double,Value>();
-	py::implicitly_convertible<std::string,Value>();
-	py::implicitly_convertible<fort::Time,Value>();
-	py::enum_<ValueType>(m,"ValueType")
-		.value("BOOL",ValueType::BOOL)
-		.value("INT",ValueType::INT)
-		.value("DOUBLE",ValueType::DOUBLE)
-		.value("STRING",ValueType::STRING)
-		.value("TIME",ValueType::TIME)
-		;
+	py::class_<Value>(m, "Value")
+	    .def(py::init<bool>())
+	    .def(py::init<int>())
+	    .def(py::init<double>())
+	    .def(py::init<std::string>())
+	    .def(py::init<fort::Time>());
+	py::implicitly_convertible<bool, Value>();
+	py::implicitly_convertible<int, Value>();
+	py::implicitly_convertible<double, Value>();
+	py::implicitly_convertible<std::string, Value>();
+	py::implicitly_convertible<fort::Time, Value>();
+	py::enum_<ValueType>(m, "ValueType")
+	    .value("BOOL", ValueType::BOOL)
+	    .value("INT", ValueType::INT)
+	    .value("DOUBLE", ValueType::DOUBLE)
+	    .value("STRING", ValueType::STRING)
+	    .value("TIME", ValueType::TIME);
+
+	py::enum_<ZonePriority>(m, "ZonePriority")
+	    .value(
+	        "PREDECENCE_HIGHER",
+	        ZonePriority::PREDECENCE_HIGHER,
+	        "Zone with Higher ZoneID will take predecence over lower ID zones"
+	    )
+	    .value(
+	        "PREDECENCE_LOWER",
+	        ZonePriority::PREDECENCE_LOWER,
+	        "Zone with lower ZoneID will take predecence over higher ID zones"
+	    )
+	    .export_values();
+
 	BindColor(m);
 
 	BindTagStatistics(m);
@@ -360,27 +372,30 @@ void BindTypes(py::module_ & m) {
 	BindAntInteraction(m);
 	BindExperimentDataInfo(m);
 
-	m.def("FormatAntID",
-	      &fort::myrmidon::FormatAntID,
-	      py::arg("antID"),
-	      R"pydoc(
+	m.def(
+	    "FormatAntID",
+	    &fort::myrmidon::FormatAntID,
+	    py::arg("antID"),
+	    R"pydoc(
     Formats an AntID to the conventional format.
 
     Args:
         antID (int): the AntID to format
     Returns:
         str: antID formatted in a string
-)pydoc");
-	m.def("FormatTagID",
-	      &fort::myrmidon::FormatTagID,
-	      py::arg("tagID"),
-	      R"pydoc(
+)pydoc"
+	);
+	m.def(
+	    "FormatTagID",
+	    &fort::myrmidon::FormatTagID,
+	    py::arg("tagID"),
+	    R"pydoc(
     Formats a TagID to the conventional format.
 
     Args:
         tagID (int): the TagID to format
     Returns:
         str: tagID formatted in a string
-)pydoc");
-
+)pydoc"
+	);
 }

--- a/bindings/python/src/Zone.cpp
+++ b/bindings/python/src/Zone.cpp
@@ -26,12 +26,13 @@ void BindZoneDefinition(py::module_ & m) {
 		;
 }
 
-void BindZone(py::module_ & m) {
+void BindZone(py::module_ &m) {
 	using namespace fort::myrmidon;
 	BindZoneDefinition(m);
-	py::class_<Zone,Zone::Ptr>(m,
-	                           "Zone",
-	                           R"pydoc(
+	py::class_<Zone, Zone::Ptr>(
+	    m,
+	    "Zone",
+	    R"pydoc(
 Defines a named region of interest for tracking and interactions
 
 Zones defines a named region of interest for tracking and
@@ -53,23 +54,32 @@ geometries. In most cases a Zone will have a single
 to add as many different ZoneDefinitions to a Zone, as long as they do
 not overlap in Time. The definitions are manipulated with
 :meth:`AddDefinition` and :meth:`DeleteDefinition`.
-)pydoc")
-		.def_property("Name",
-		     &Zone::Name,
-		     &Zone::SetName,
-		     "str: the name of the Zone")
-		.def_property_readonly("ID",
-		                       &Zone::ID,
-		                       "int: the unique ID for this Zone")
-		.def_property_readonly("Definitions",
-		                       &Zone::Definitions,
-		                       py::return_value_policy::reference_internal,
-		                       "List[ZoneDefinition]: the definitions for this Zone")
-		.def("AddDefinition",&Zone::AddDefinition,
-		     py::arg("shapes") = py::list(),
-		     py::arg("start") = fort::Time::SinceEver(),
-		     py::arg("end") = fort::Time::Forever(),
-		     R"pydoc(
+)pydoc"
+	)
+	    .def_property(
+	        "Name",
+	        &Zone::Name,
+	        &Zone::SetName,
+	        "str: the name of the Zone"
+	    )
+	    .def_property_readonly(
+	        "ID",
+	        &Zone::ID,
+	        "int: the unique ID for this Zone"
+	    )
+	    .def_property_readonly(
+	        "Definitions",
+	        &Zone::Definitions,
+	        py::return_value_policy::reference_internal,
+	        "List[ZoneDefinition]: the definitions for this Zone"
+	    )
+	    .def(
+	        "AddDefinition",
+	        &Zone::AddDefinition,
+	        py::arg("shapes") = py::list(),
+	        py::arg("start")  = fort::Time::SinceEver(),
+	        py::arg("end")    = fort::Time::Forever(),
+	        R"pydoc(
     Adds a new ZoneDefinition to this Zone
 
     Args:
@@ -86,17 +96,21 @@ not overlap in Time. The definitions are manipulated with
     Raises:
         ValueError: if start or end would make an overlapping
             definition with another ZoneDefinition of this Zone
-)pydoc")
-		.def("DeleteDefinition",
-		     &Zone::DeleteDefinition,
-		     py::arg("index"),
-		     R"pydoc(
+)pydoc"
+	    )
+	    .def(
+	        "DeleteDefinition",
+	        &Zone::DeleteDefinition,
+	        py::arg("index"),
+	        R"pydoc(
     Removes a ZoneDefinition
 
     Args:
         index (int): the index in :attr:`Definitions` to remove.
     Raises:
         IndexError: if index >= len(self.Definitions)
-)pydoc")
-		;
+)pydoc"
+	    )
+	    .def("__str__", [](const Zone::Ptr &z) { return z->Format(); })
+	    .def("__repr__", [](const Zone::Ptr &z) { return z->Format(); });
 }

--- a/bindings/python/tests/test_ant.py
+++ b/bindings/python/tests/test_ant.py
@@ -129,3 +129,16 @@ class AntTestCase(unittest.TestCase):
         self.experiment.SetMetaDataKey("alive", True)
         self.experiment = None
         a.SetValue("alive", False, m.Time())
+
+    def test_ant_formatting(self):
+        a = self.experiment.CreateAnt()
+        t1 = m.Time.Now()
+        t2 = t1.Add(1 * m.Duration.Second)
+
+        i3 = self.experiment.AddIdentification(a.ID, 2, t2, m.Time.Forever())
+        i2 = self.experiment.AddIdentification(a.ID, 1, t1, t2)
+        i1 = self.experiment.AddIdentification(a.ID, 0, m.Time.SinceEver(), t1)
+
+        expected = "Ant{ID:001,↤{0x000,0x001,0x002}}"
+        self.assertEqual(str(a), expected)
+        self.assertEqual(repr(a), expected)

--- a/bindings/python/tests/test_identification.py
+++ b/bindings/python/tests/test_identification.py
@@ -72,6 +72,7 @@ class IdentificationTestCase(unittest.TestCase, assertions.CustomAssertion):
 
     def test_formatting(self):
         self.assertEqual(str(self.i), "Identification{ID:0x07b ↦ 1, From:-∞, To:+∞}")
+        self.assertEqual(repr(self.i), "Identification{ID:0x07b ↦ 1, From:-∞, To:+∞}")
 
     def test_scope_validity(self):
         self.experiment = None

--- a/bindings/python/tests/test_matchers.py
+++ b/bindings/python/tests/test_matchers.py
@@ -15,6 +15,10 @@ class MatchersTestCase(unittest.TestCase):
             ),
             (m.Matcher.AntID(1), "Ant.ID == 001"),
             (m.Matcher.AntMetaData(key="group", value="nurse"), "Ant.'group' == nurse"),
+            (
+                m.Matcher.AntMetaData(key="group", value=None),
+                "Ant1.'group' == Ant2.'group'",
+            ),
             (m.Matcher.AntDistanceSmallerThan(10.0), "Distance(Ant1, Ant2) < 10"),
             (m.Matcher.AntDistanceGreaterThan(10.0), "Distance(Ant1, Ant2) > 10"),
             (m.Matcher.AntAngleSmallerThan(1.0), "Angle(Ant1, Ant2) < 1"),
@@ -28,3 +32,4 @@ class MatchersTestCase(unittest.TestCase):
         ]
         for matcher, e in testdata:
             self.assertEqual(str(matcher), e)
+            self.assertEqual(repr(matcher), e)

--- a/bindings/python/tests/test_shapes.py
+++ b/bindings/python/tests/test_shapes.py
@@ -106,6 +106,18 @@ class ShapeTestCase(unittest.TestCase):
         npt.assert_almost_equal(self.polygon.Vertices[2], [1, -1])
         npt.assert_almost_equal(self.polygon.Vertices[3], [2, 3])
 
+    def test_format(self):
+        self.assertEqual(str(self.circle), "Circle{Center:{0 0},Radius:1}")
+        self.assertEqual(repr(self.circle), "Circle{Center:{0 0},Radius:1}")
+        self.assertEqual(
+            str(self.polygon), "Polygon{Vertices:{{1 1},{-1  1},{-1 -1},{ 1 -1}}}"
+        )
+        self.assertEqual(
+            repr(self.polygon), "Polygon{Vertices:{{1 1},{-1  1},{-1 -1},{ 1 -1}}}"
+        )
+        self.assertEqual(str(self.capsule), "Capsule{C1:{0 0},R1:1,C2:{1 1},R2:1}")
+        self.assertEqual(repr(self.capsule), "Capsule{C1:{0 0},R1:1,C2:{1 1},R2:1}")
+
 
 class ShapeListTestCase(unittest.TestCase):
     def test_initialization(self):

--- a/bindings/python/tests/test_space.py
+++ b/bindings/python/tests/test_space.py
@@ -38,3 +38,7 @@ class SpaceTestCase(unittest.TestCase):
         self.assertEqual(frame, 0)
         with self.assertRaises(IndexError):
             filepath, frame = self.experiment.Spaces[1].LocateMovieFrame(tddInfo.End)
+
+    def test_format(self):
+        self.assertEqual(str(self.space), "Space{ID:1,Name:'foo',Zones:0}")
+        self.assertEqual(repr(self.space), "Space{ID:1,Name:'foo',Zones:0}")

--- a/bindings/python/tests/test_zone.py
+++ b/bindings/python/tests/test_zone.py
@@ -72,3 +72,8 @@ class ZoneTestCase(unittest.TestCase):
         definitions[0].End = m.Time().Add(-1)
         definitions[1].Start = m.Time().Add(1)
         zone.AddDefinition([], start=m.Time().Add(-1), end=m.Time().Add(1))
+
+    def test_format(self):
+        zone = self.space.CreateZone("feeding_area")
+        self.assertEqual(str(zone), "Zone{ID:1,Name:'feeding_area',Definitions:0}")
+        self.assertEqual(repr(zone), "Zone{ID:1,Name:'feeding_area',Definitions:0}")

--- a/docs/api/python/misc.rst
+++ b/docs/api/python/misc.rst
@@ -25,3 +25,10 @@ Colors in **fort_myrmidon** are simply :obj:`Tuple[int,int,int]`.
 
 .. autofunction:: fort_myrmidon.DefaultPalette
 .. autofunction:: fort_myrmidon.DefaultPaletteColor
+
+
+ZonePriority
+++++++++++++
+
+.. autoclass:: fort_myrmidon.ZonePriority
+   :members:

--- a/src/fort/myrmidon/Ant.cpp
+++ b/src/fort/myrmidon/Ant.cpp
@@ -1,24 +1,24 @@
 #include "Ant.hpp"
 
-
+#include "fort/myrmidon/types/Typedefs.hpp"
 #include "handle/AntHandle.hpp"
 
+#include "Identification.hpp"
 #include "priv/Ant.hpp"
 
 namespace fort {
 namespace myrmidon {
 
 Ant::Ant(std::unique_ptr<AntHandle> handle)
-	: d_p(std::move(handle)) {
-}
+    : d_p(std::move(handle)) {}
 
 Ant::~Ant() = default;
 
-TagID Ant::IdentifiedAt(const Time & time) const {
+TagID Ant::IdentifiedAt(const Time &time) const {
 	return d_p->Get().IdentifiedAt(time);
 }
 
-const IdentificationList & Ant::Identifications() const{
+const IdentificationList &Ant::Identifications() const {
 	return d_p->Identifications();
 }
 
@@ -26,11 +26,11 @@ AntID Ant::ID() const {
 	return d_p->Get().AntID();
 }
 
-const Color & Ant::DisplayColor() const {
+const Color &Ant::DisplayColor() const {
 	return d_p->Get().DisplayColor();
 }
 
-void Ant::SetDisplayColor(const Color & color) {
+void Ant::SetDisplayColor(const Color &color) {
 	d_p->Get().SetDisplayColor(color);
 }
 
@@ -42,32 +42,31 @@ void Ant::SetDisplayStatus(DisplayState s) {
 	d_p->Get().SetDisplayStatus(s);
 }
 
-const Value & Ant::GetValue(const std::string & name,
-                                      const Time & time) const {
-	return d_p->Get().GetValue(name,time);
+const Value &Ant::GetValue(const std::string &name, const Time &time) const {
+	return d_p->Get().GetValue(name, time);
 }
 
-void Ant::SetValue(const std::string & name,
-                   const Value & value,
-                   const Time & time) {
-	d_p->Get().SetValue(name,value,time);
+void Ant::SetValue(
+    const std::string &name, const Value &value, const Time &time
+) {
+	d_p->Get().SetValue(name, value, time);
 }
 
-const std::map<Time,Value> & Ant::GetValues(const std::string & key) const {
+const std::map<Time, Value> &Ant::GetValues(const std::string &key) const {
 	return d_p->Get().GetValues(key);
 }
 
-void Ant::DeleteValue(const std::string & name,
-                      const Time & time) {
-	d_p->Get().DeleteValue(name,time);
+void Ant::DeleteValue(const std::string &name, const Time &time) {
+	d_p->Get().DeleteValue(name, time);
 }
 
-void Ant::AddCapsule(AntShapeTypeID shapeTypeID,
-                     const std::shared_ptr<Capsule> & capsule) {
-	d_p->Get().AddCapsule(shapeTypeID,capsule);
+void Ant::AddCapsule(
+    AntShapeTypeID shapeTypeID, const std::shared_ptr<Capsule> &capsule
+) {
+	d_p->Get().AddCapsule(shapeTypeID, capsule);
 }
 
-const TypedCapsuleList & Ant::Capsules() const {
+const TypedCapsuleList &Ant::Capsules() const {
 	return d_p->Get().Capsules();
 }
 
@@ -79,6 +78,20 @@ void Ant::ClearCapsules() {
 	d_p->Get().ClearCapsules();
 }
 
-
 } // namespace myrmidon
 } // namespace fort
+
+std::ostream &operator<<(std::ostream &out, const fort::myrmidon::Ant &a) {
+
+	out << "Ant{ID:" << fort::myrmidon::FormatAntID(a.ID()) << ",↤";
+	std::set<fort::myrmidon::TagID> ids;
+	for (const auto &idt : a.Identifications()) {
+		ids.insert(idt->TagValue());
+	}
+	std::string sep = "{";
+	for (const auto id : ids) {
+		out << sep << fort::myrmidon::FormatTagID(id);
+		sep = ",";
+	}
+	return out << "}}";
+}

--- a/src/fort/myrmidon/Ant.hpp
+++ b/src/fort/myrmidon/Ant.hpp
@@ -74,24 +74,24 @@ public:
 	/**
 	 * A pointer to an Ant
 	 */
-	typedef std::shared_ptr<Ant>       Ptr;
+	typedef std::shared_ptr<Ant> Ptr;
 
 	/**
 	 * The DisplayState of an Ant in an Experiment
 	 */
 	enum class DisplayState {
-	                         /**
-	                          * the Ant is visible
-	                          */
-	                         VISIBLE = 0,
-	                         /**
-	                          * the Ant is hidden
-	                          */
-	                         HIDDEN  = 1,
-	                         /**
-	                          * Ant is visible and all non-SOLO Ant will be hidden.
-	                          */
-	                         SOLO    = 2,
+		/**
+		 * the Ant is visible
+		 */
+		VISIBLE = 0,
+		/**
+		 * the Ant is hidden
+		 */
+		HIDDEN  = 1,
+		/**
+		 * Ant is visible and all non-SOLO Ant will be hidden.
+		 */
+		SOLO    = 2,
 	};
 
 	/**
@@ -106,10 +106,10 @@ public:
 	 *
 	 * @return a ::TagID that identify this ant at this time.
 	 *
-	 * @throws std::runtime_error if there no valid Identification for this time.
+	 * @throws std::runtime_error if there no valid Identification for this
+	 * time.
 	 */
-	TagID IdentifiedAt(const Time & time) const;
-
+	TagID IdentifiedAt(const Time &time) const;
 
 	/**
 	 * Gets the Identification targetting this Ant.
@@ -117,9 +117,10 @@ public:
 	 * Gets the Identification targetting this Ant. These
 	 * Identification will always be sorted in Time and never overlaps.
 	 *
-	 * @return an Identification::List of Identification that target this object.
+	 * @return an Identification::List of Identification that target this
+	 * object.
 	 */
-	const IdentificationList & Identifications() const;
+	const IdentificationList &Identifications() const;
 
 	/**
 	 *  Gets the AntID of an Ant.
@@ -131,7 +132,6 @@ public:
 	 */
 	fort::myrmidon::AntID ID() const;
 
-
 	/**
 	 *  Gets the Display Color of an Ant.
 	 *
@@ -140,8 +140,7 @@ public:
 	 * @return a const reference to the Color used to display the Ant
 	 *         in `fort-studio`.
 	 */
-	const Color & DisplayColor() const;
-
+	const Color &DisplayColor() const;
 
 	/**
 	 * Sets the Ant display color
@@ -149,7 +148,7 @@ public:
 	 * @param color the new Color to use to display the Ant in `fort-studio`.
 	 */
 
-	void SetDisplayColor(const Color & color);
+	void SetDisplayColor(const Color &color);
 
 	/**
 	 *  Gets the Ant display state
@@ -186,10 +185,10 @@ public:
 	 *
 	 * @return the wanted Value for key at time, or the Experiment default one
 	 *
-	 * @throws std::out_of_range if name is not a defined metadata key in Experiment.
+	 * @throws std::out_of_range if name is not a defined metadata key in
+	 * Experiment.
 	 */
-	const Value & GetValue(const std::string & key,
-	                                const Time & time) const;
+	const Value &GetValue(const std::string &key, const Time &time) const;
 
 	/**
 	 *  Sets a user defined timed metadata
@@ -208,9 +207,7 @@ public:
 	 * @throws std::runtime_error if value is not of the right type for key
 	 *
 	 */
-	void SetValue(const std::string & key,
-	              const Value & value,
-	              const Time & time);
+	void SetValue(const std::string &key, const Value &value, const Time &time);
 
 	/**
 	 * Removes any user defined value at a given time
@@ -223,8 +220,7 @@ public:
 	 * @throws std::out_of_range if no value for key at time have
 	 *         been previously set with SetValue().
 	 */
-	void DeleteValue(const std::string & key,
-	                 const Time & time);
+	void DeleteValue(const std::string &key, const Time &time);
 
 	/**
 	 * Gets all metadata key value changes over time
@@ -232,7 +228,7 @@ public:
 	 * @param key the key to list
 	 * @return the values of key over the time
 	 */
-	const std::map<Time,Value> & GetValues(const std::string & key) const;
+	const std::map<Time, Value> &GetValues(const std::string &key) const;
 
 	/**
 	 *  Adds a Capsule to the Ant virtual shape list.
@@ -245,8 +241,9 @@ public:
 	 *
 	 * @throws std::invalid_argument if shapeTypeID is not defined in Experiment
 	 */
-	void AddCapsule(AntShapeTypeID shapeTypeID,
-	                const std::shared_ptr<Capsule> & capsule);
+	void AddCapsule(
+	    AntShapeTypeID shapeTypeID, const std::shared_ptr<Capsule> &capsule
+	);
 
 	/**
 	 * Gets all capsules for this Ant
@@ -254,14 +251,15 @@ public:
 	 * @return a TypedCapsuleList representing the virtual shape of
 	 *        the Ant
 	 */
-	const TypedCapsuleList & Capsules() const;
+	const TypedCapsuleList &Capsules() const;
 
 	/**
 	 * Delete one of the virtual shape
 	 *
 	 * @param index the index in the Capsules() to remove
 	 *
-	 * @throws std::out_of_range if index is greate or equal to the size of Capsules().
+	 * @throws std::out_of_range if index is greate or equal to the size of
+	 * Capsules().
 	 */
 	void DeleteCapsule(const size_t index);
 
@@ -283,12 +281,13 @@ private:
 	// from <Experiment>.
 	Ant(std::unique_ptr<AntHandle> handle);
 
-	Ant & operator=(const Ant &) = delete;
-	Ant(const Ant &) = delete;
+	Ant &operator=(const Ant &) = delete;
+	Ant(const Ant &)            = delete;
 
 	std::unique_ptr<AntHandle> d_p;
 };
 
-
 } // namespace myrmidon
-} //namespace fort
+} // namespace fort
+
+std::ostream &operator<<(std::ostream &, const fort::myrmidon::Ant &);

--- a/src/fort/myrmidon/Query.hpp
+++ b/src/fort/myrmidon/Query.hpp
@@ -101,8 +101,10 @@ public:
 	 * Arguments for IdentifyFrames() and IdentifyFramesFunctor().
 	 */
 	struct IdentifyFramesArgs : public QueryArgs {
-		//! enables zone computation without collision detection
-		bool ComputeZones = true;
+		//! sets zone computation depth.
+		size_t       ZoneDepth = 1;
+		//! sets zones computation predecence.
+		ZonePriority Order     = ZonePriority::PREDECENCE_LOWER;
 	};
 
 	/**
@@ -153,7 +155,7 @@ public:
 	 *
 	 * Arguments for CollideFrames() and CollideFramesFunctor().
 	 */
-	struct CollideFramesArgs : public QueryArgs {
+	struct CollideFramesArgs : public IdentifyFramesArgs {
 		//! Collision detection happens over different zones (default: false).
 		bool CollisionsIgnoreZones = false;
 	};
@@ -203,7 +205,7 @@ public:
 	 * Arguments for ComputeAntTrajectories() and
 	 * ComputeAntTrajectoriesFunctor().
 	 */
-	struct ComputeAntTrajectoriesArgs : public QueryArgs {
+	struct ComputeAntTrajectoriesArgs : public IdentifyFramesArgs {
 		//! Maximum Duration before considering the trajectory be two
 		//! different parts (default: 1s)
 		Duration MaximumGap = Duration::Second;
@@ -211,9 +213,6 @@ public:
 		//! Matcher to reduce the query to an Ant subset (default: to
 		//! nullptr, i.e. anything).
 		std::shared_ptr<myrmidon::Matcher> Matcher = nullptr;
-
-		//! Computes the zone of each Ant (default: false)
-		bool ComputeZones = false;
 
 		//! If a combined matcher value changes, create a new object
 		bool SegmentOnMatcherValueChange = false;
@@ -268,7 +267,7 @@ public:
 	 * Arguments for ComputeAntInteractions() and
 	 * ComputeAntInteractionsFunctor().
 	 */
-	struct ComputeAntInteractionsArgs : public QueryArgs {
+	struct ComputeAntInteractionsArgs : public CollideFramesArgs {
 		//! Maximum Duration before considering the trajectory be two
 		//! different parts (default: 1s)
 		Duration MaximumGap = Duration::Second;
@@ -282,10 +281,6 @@ public:
 		//! will be computed like ComputeAntTrajectories() and
 		//! AntInteraction wil points to sub-segment (default: true).
 		bool ReportFullTrajectories = true;
-
-		//! Collisions, and therefore interactions, happens over
-		//! different zones.
-		bool CollisionsIgnoreZones = false;
 
 		//! If a combined matcher value changes, create a new object
 		bool SegmentOnMatcherValueChange = false;

--- a/src/fort/myrmidon/Shapes.cpp
+++ b/src/fort/myrmidon/Shapes.cpp
@@ -3,37 +3,34 @@
 #include <Eigen/Dense>
 
 #include <fort/myrmidon/priv/Isometry2D.hpp>
+#include <sstream>
 
-#define PRIV(Class) (static_cast<priv::Class*>(d_ptr))
+#define PRIV(Class) (static_cast<priv::Class *>(d_ptr))
 
 namespace fort {
 namespace myrmidon {
 
 Shape::Shape(Type type)
-	: d_type(type) {
-}
+    : d_type(type) {}
 
 Shape::Type Shape::ShapeType() const {
 	return d_type;
 }
 
-Shape::~Shape() {
-}
+Shape::~Shape() {}
 
-Circle::Circle(const Eigen::Vector2d & center, double radius)
-	: Shape(Type::CIRCLE)
-	, d_center(center)
-	, d_radius(radius) {
-}
+Circle::Circle(const Eigen::Vector2d &center, double radius)
+    : Shape(Type::CIRCLE)
+    , d_center(center)
+    , d_radius(radius) {}
 
-Circle::~Circle() {
-}
+Circle::~Circle() {}
 
-void Circle::SetCenter( const Eigen::Vector2d & center) {
+void Circle::SetCenter(const Eigen::Vector2d &center) {
 	d_center = center;
 }
 
-const Eigen::Vector2d & Circle::Center() const {
+const Eigen::Vector2d &Circle::Center() const {
 	return d_center;
 }
 
@@ -45,50 +42,44 @@ double Circle::Radius() const {
 	return d_radius;
 }
 
-bool Circle::Contains(const Eigen::Vector2d & point) const {
-	return (point - d_center).squaredNorm() <= d_radius*d_radius;
+bool Circle::Contains(const Eigen::Vector2d &point) const {
+	return (point - d_center).squaredNorm() <= d_radius * d_radius;
 }
 
 AABB Circle::ComputeAABB() const {
-	Eigen::Vector2d r(d_radius,d_radius);
-	return AABB( d_center - r, d_center + r);
+	Eigen::Vector2d r(d_radius, d_radius);
+	return AABB(d_center - r, d_center + r);
 }
 
 std::unique_ptr<Shape> Circle::Clone() const {
 	return std::make_unique<Circle>(*this);
 }
 
-
 Capsule::Capsule()
-	: Shape(Type::CAPSULE)
-	, d_c1(0,0)
-	, d_c2(0,0)
-	, d_r1(0)
-	, d_r2(0) {
-}
+    : Shape(Type::CAPSULE)
+    , d_c1(0, 0)
+    , d_c2(0, 0)
+    , d_r1(0)
+    , d_r2(0) {}
 
-Capsule::Capsule(const Eigen::Vector2d & c1,
-                 const Eigen::Vector2d & c2,
-                 double r1,
-                 double r2)
-	: Shape(Type::CAPSULE)
-	, d_c1(c1)
-	, d_c2(c2)
-	, d_r1(r1)
-	, d_r2(r2){
-}
+Capsule::Capsule(
+    const Eigen::Vector2d &c1, const Eigen::Vector2d &c2, double r1, double r2
+)
+    : Shape(Type::CAPSULE)
+    , d_c1(c1)
+    , d_c2(c2)
+    , d_r1(r1)
+    , d_r2(r2) {}
 
-Capsule::~Capsule() {
-}
+Capsule::~Capsule() {}
 
-void Capsule::SetC1(const Eigen::Vector2d & c1) {
+void Capsule::SetC1(const Eigen::Vector2d &c1) {
 	d_c1 = c1;
 }
 
-void Capsule::SetC2(const Eigen::Vector2d & c2) {
+void Capsule::SetC2(const Eigen::Vector2d &c2) {
 	d_c2 = c2;
 }
-
 
 void Capsule::SetR1(double r1) {
 	d_r1 = r1;
@@ -98,25 +89,26 @@ void Capsule::SetR2(double r2) {
 	d_r2 = r2;
 }
 
-template <typename T>
-inline T clamp(T value, T lower, T upper) {
-	if ( value <= lower ) {
+template <typename T> inline T clamp(T value, T lower, T upper) {
+	if (value <= lower) {
 		return lower;
 	}
-	if ( value > upper ) {
+	if (value > upper) {
 		return upper;
 	}
 	return value;
 }
 
-bool Capsule::Intersect(const Eigen::Vector2d & aC1,
-                        const Eigen::Vector2d & aC2,
-                        double aR1,
-                        double aR2,
-                        const Eigen::Vector2d & bC1,
-                        const Eigen::Vector2d & bC2,
-                        double bR1,
-                        double bR2) {
+bool Capsule::Intersect(
+    const Eigen::Vector2d &aC1,
+    const Eigen::Vector2d &aC2,
+    double                 aR1,
+    double                 aR2,
+    const Eigen::Vector2d &bC1,
+    const Eigen::Vector2d &bC2,
+    double                 bR1,
+    double                 bR2
+) {
 
 	// To rapidly test collision between towo capsule, we project a
 	// center of a capsule on the segment of the other capsule, and
@@ -137,146 +129,142 @@ bool Capsule::Intersect(const Eigen::Vector2d & aC1,
 	// threshold, but detection will occurs if the capsule goes closer
 	// to one another. Won't affect detection of interactions.
 
-
-#define constraintToSegment(t,projected,point,start,startToEnd) do { \
-		t = (point - start).dot(startToEnd) / startToEnd.dot(startToEnd); \
-		t = clamp(t,0.0,1.0); \
-		projected = t * startToEnd + start; \
-	} while(0)
+#define constraintToSegment(t, projected, point, start, startToEnd)            \
+	do {                                                                       \
+		t = (point - start).dot(startToEnd) / startToEnd.dot(startToEnd);      \
+		t = clamp(t, 0.0, 1.0);                                                \
+		projected = t * startToEnd + start;                                    \
+	} while (0)
 
 	Eigen::Vector2d aCC = aC2 - aC1;
 	Eigen::Vector2d bCC = bC2 - bC1;
 
 	Eigen::Vector2d proj;
-	double t,sumRadius;
+	double          t, sumRadius;
 
-#define intersect(point,startSegment,segment,pRadius1,pRadius2,radius) do {	  \
-		constraintToSegment(t,proj,point,startSegment,segment); \
-		double distSqrd = (proj-point).squaredNorm(); \
-		/* std::cerr << "Projecting " << #point << " on " << #segment << " t: " << t << std::endl; */\
-		if ( distSqrd < 1.0e-6 ) { \
-			/* Segments intersects */ \
-			return true; \
-		} \
-		sumRadius = pRadius1 + t * (pRadius2 - pRadius1) + radius; \
-		sumRadius *= sumRadius; \
-		/*std::cerr << "sumRadius " << sumRadius << " tA " << tA << " tB " << tB <<  " aR1 " << aR1 << " bR1 " << bR1 << std::endl; */ \
-		if ( distSqrd <= sumRadius ) { \
-			return true; \
-		} \
-	}while(0)
+#define intersect(point, startSegment, segment, pRadius1, pRadius2, radius)    \
+	do {                                                                       \
+		constraintToSegment(t, proj, point, startSegment, segment);            \
+		double distSqrd = (proj - point).squaredNorm();                        \
+		/* std::cerr << "Projecting " << #point << " on " << #segment << " t:  \
+		 * " << t << std::endl; */                                             \
+		if (distSqrd < 1.0e-6) {                                               \
+			/* Segments intersects */                                          \
+			return true;                                                       \
+		}                                                                      \
+		sumRadius = pRadius1 + t * (pRadius2 - pRadius1) + radius;             \
+		sumRadius *= sumRadius;                                                \
+		/*std::cerr << "sumRadius " << sumRadius << " tA " << tA << " tB " <<  \
+		 * tB <<  " aR1 " << aR1 << " bR1 " << bR1 << std::endl; */            \
+		if (distSqrd <= sumRadius) {                                           \
+			return true;                                                       \
+		}                                                                      \
+	} while (0)
 
-	intersect(bC1,aC1,aCC,aR1,aR2,bR1);
-	intersect(bC2,aC1,aCC,aR1,aR2,bR2);
-	intersect(aC1,bC1,bCC,bR1,bR2,aR1);
-	intersect(aC2,bC1,bCC,bR1,bR2,aR2);
+	intersect(bC1, aC1, aCC, aR1, aR2, bR1);
+	intersect(bC2, aC1, aCC, aR1, aR2, bR2);
+	intersect(aC1, bC1, bCC, bR1, bR2, aR1);
+	intersect(aC2, bC1, bCC, bR1, bR2, aR2);
 
 	return false;
 }
 
-bool Capsule::Contains(const Eigen::Vector2d & point) const {
-	Eigen::Vector2d cc = d_c2 - d_c1;
-	double t = (point - d_c1).dot(cc) / cc.squaredNorm();
-	t = clamp(t,0.0,1.0);
-	double r = d_r1 + t * (d_r2 - d_r1);
+bool Capsule::Contains(const Eigen::Vector2d &point) const {
+	Eigen::Vector2d cc   = d_c2 - d_c1;
+	double          t    = (point - d_c1).dot(cc) / cc.squaredNorm();
+	t                    = clamp(t, 0.0, 1.0);
+	double          r    = d_r1 + t * (d_r2 - d_r1);
 	Eigen::Vector2d diff = point - d_c1 - t * cc;
-	return diff.squaredNorm() <= r*r;
+	return diff.squaredNorm() <= r * r;
 }
 
 AABB Capsule::ComputeAABB() const {
-	Eigen::Vector2d r1(d_r1,d_r1),r2(d_r2,d_r2);
-	AABB res(d_c1 - r1,d_c1 + r1);
-	res.extend(AABB(d_c2 -r2, d_c2 + r2));
+	Eigen::Vector2d r1(d_r1, d_r1), r2(d_r2, d_r2);
+	AABB            res(d_c1 - r1, d_c1 + r1);
+	res.extend(AABB(d_c2 - r2, d_c2 + r2));
 	return res;
 }
 
-Capsule Capsule::Transform(const priv::Isometry2Dd & transform) const {
-	return myrmidon::Capsule(transform * d_c1,
-	                         transform * d_c2,
-	                         d_r1,
-	                         d_r2);
+Capsule Capsule::Transform(const priv::Isometry2Dd &transform) const {
+	return myrmidon::Capsule(transform * d_c1, transform * d_c2, d_r1, d_r2);
 }
 
 std::unique_ptr<Shape> Capsule::Clone() const {
 	return std::make_unique<Capsule>(*this);
 }
 
-
-Polygon::Polygon(const Vector2dList & vertices)
-	: Shape(Type::POLYGON)
-	, d_vertices(vertices) {
-	if (d_vertices.size() < 3 ) {
+Polygon::Polygon(const Vector2dList &vertices)
+    : Shape(Type::POLYGON)
+    , d_vertices(vertices) {
+	if (d_vertices.size() < 3) {
 		throw std::invalid_argument("A polygon needs at least 3 points");
 	}
 }
 
-Polygon::~Polygon() {
-}
+Polygon::~Polygon() {}
 
 size_t Polygon::Size() const {
 	return d_vertices.size();
 }
 
-const Eigen::Vector2d & Polygon::Vertex(size_t i) const {
+const Eigen::Vector2d &Polygon::Vertex(size_t i) const {
 	return d_vertices.at(i);
 }
 
-void Polygon::SetVertex(size_t i, const Eigen::Vector2d & v) {
+void Polygon::SetVertex(size_t i, const Eigen::Vector2d &v) {
 	d_vertices.at(i) = v;
 }
 
 void Polygon::DeleteVertex(size_t i) {
-	if ( i >= d_vertices.size() ) {
-		throw std::out_of_range("index "
-		                        + std::to_string(i)
-		                        + " should be in [0;"
-		                        + std::to_string(d_vertices.size())
-		                        + "[");
+	if (i >= d_vertices.size()) {
+		throw std::out_of_range(
+		    "index " + std::to_string(i) + " should be in [0;" +
+		    std::to_string(d_vertices.size()) + "["
+		);
 	}
-	d_vertices.erase(d_vertices.begin()+i);
+	d_vertices.erase(d_vertices.begin() + i);
 }
 
-
-const Vector2dList & Polygon::Vertices() const {
+const Vector2dList &Polygon::Vertices() const {
 	return d_vertices;
 }
 
-void Polygon::SetVertices(const Vector2dList & vertices) {
+void Polygon::SetVertices(const Vector2dList &vertices) {
 	d_vertices = vertices;
 }
 
-
 AABB Polygon::ComputeAABB() const {
-	AABB res(d_vertices[0],d_vertices[1]);
-	for ( size_t i = 2; i < d_vertices.size(); ++i) {
+	AABB res(d_vertices[0], d_vertices[1]);
+	for (size_t i = 2; i < d_vertices.size(); ++i) {
 		res.extend(d_vertices[i]);
 	}
 	return res;
 }
 
-
-bool Polygon::Contains(const Eigen::Vector2d & p) const {
+bool Polygon::Contains(const Eigen::Vector2d &p) const {
 	// O if on line, >0 if on left,  <0  if on right
-#define side_criterion(start,end,point) ( (end-start).dot(Eigen::Vector2d(point.y() - start.y(),start.x() - point.x())) )
+#define side_criterion(start, end, point)                                      \
+	((end - start)                                                             \
+	     .dot(Eigen::Vector2d(point.y() - start.y(), start.x() - point.x())))
 
 	int windingNumber = 0;
-	for ( size_t i =0; i < d_vertices.size(); ++i) {
-		const auto & a = d_vertices[i];
-		const auto & b = d_vertices[(i+1) % d_vertices.size()];
-		if ( p.y() >= a.y() ) {
-			if ( p.y() >= b.y() ) {
+	for (size_t i = 0; i < d_vertices.size(); ++i) {
+		const auto &a = d_vertices[i];
+		const auto &b = d_vertices[(i + 1) % d_vertices.size()];
+		if (p.y() >= a.y()) {
+			if (p.y() >= b.y()) {
 				continue;
 			}
 			// p.y() < b.y()
-			if ( side_criterion(a,b,p) > 0.0 ) {
+			if (side_criterion(a, b, p) > 0.0) {
 				++windingNumber;
 			}
 		} else { // p.y() < a.y()
-			if ( p.y() < b.y() ) {
+			if (p.y() < b.y()) {
 				continue;
 			}
 			// p.y() >= b.y()
-			if ( side_criterion(a,b,p) < 0.0 ) {
+			if (side_criterion(a, b, p) < 0.0) {
 				--windingNumber;
 			}
 		}
@@ -289,10 +277,36 @@ std::unique_ptr<Shape> Polygon::Clone() const {
 	return std::make_unique<Polygon>(*this);
 }
 
-std::ostream & operator<<(std::ostream & out,
-                          const fort::myrmidon::Capsule & c) {
-	return out << "Capsule{C1:{" << c.C1().transpose() << "},R1:" << c.R1()
-	           << ",C2:{" << c.C2().transpose() << "},R2:" << c.R2() << "}";
+std::string Capsule::Format() const {
+	std::ostringstream oss;
+	oss << "Capsule{C1:{" << d_c1.transpose() << "},R1:" << d_r1 << ",C2:{"
+	    << d_c2.transpose() << "},R2:" << d_r2 << "}";
+	return oss.str();
+}
+
+std::string Circle::Format() const {
+	std::ostringstream oss;
+	oss << "Circle{Center:{" << d_center.transpose() << "},Radius:" << d_radius
+	    << "}";
+	return oss.str();
+}
+
+std::string Polygon::Format() const {
+	std::ostringstream oss;
+	oss << "Polygon{Vertices:";
+	std::string sep = "{";
+	for (const auto &v : d_vertices) {
+		oss << sep << "{" << v.transpose() << "}";
+		sep = ",";
+	}
+	oss << "}}";
+	return oss.str();
+}
+
+std::ostream &operator<<(std::ostream &out, const fort::myrmidon::Capsule &c) {
+	// return out << "Capsule{C1:{" << c.C1().transpose() << "},R1:" << c.R1()
+	//            << ",C2:{" << c.C2().transpose() << "},R2:" << c.R2() << "}";
+	return out << c.Format();
 }
 
 } // namespace myrmidon

--- a/src/fort/myrmidon/Shapes.hpp
+++ b/src/fort/myrmidon/Shapes.hpp
@@ -65,6 +65,8 @@ public:
 	 */
 	Type ShapeType() const;
 
+	virtual std::string Format() const = 0;
+
 	/** \cond PRIVATE */
 	virtual bool Contains(const Eigen::Vector2d & point) const = 0;
 
@@ -86,7 +88,7 @@ protected:
 class Circle : public Shape {
 public:
 	/** A pointer to a Circle */
-	typedef std::shared_ptr<Circle>       Ptr;
+	typedef std::shared_ptr<Circle> Ptr;
 
 	/**
 	 *  public constructor
@@ -94,7 +96,7 @@ public:
 	 * @param center the center of the circle
 	 * @param radius the radius of the circle
 	 */
-	Circle(const Eigen::Vector2d & center, double radius);
+	Circle(const Eigen::Vector2d &center, double radius);
 
 	virtual ~Circle();
 
@@ -103,15 +105,14 @@ public:
 	 *
 	 * @param center the center of the circle
 	 */
-	void SetCenter( const Eigen::Vector2d & center);
+	void SetCenter(const Eigen::Vector2d &center);
 
 	/**
 	 *  Gets the center of the circle
 	 *
 	 * @return the circle center
 	 */
-	const Eigen::Vector2d & Center() const;
-
+	const Eigen::Vector2d &Center() const;
 
 	/**
 	 *  Sets the radius of the circle
@@ -127,9 +128,11 @@ public:
 	 */
 	double Radius() const;
 
+	std::string Format() const override;
+
 	/** \cond PRIVATE */
 
-	bool Contains(const Eigen::Vector2d & point) const override;
+	bool Contains(const Eigen::Vector2d &point) const override;
 
 	AABB ComputeAABB() const override;
 
@@ -139,7 +142,7 @@ public:
 	/** \endcond PRIVATE */
 private:
 	Eigen::Vector2d d_center;
-	double d_radius;
+	double          d_radius;
 };
 
 /**
@@ -241,6 +244,8 @@ public:
 		return d_r2;
 	}
 
+	std::string Format() const override;
+
 	/** \cond PRIVATE */
 	bool Contains(const Eigen::Vector2d & point) const override;
 
@@ -283,19 +288,19 @@ private:
  * Note that order matters as {(-1,-1),(1,-1),(1,1),(-1,1)} is a
  * square, and {(-1,-1),(1,-1),(-1,1),(1,1)} is an hourglass.
  */
-class Polygon  : public Shape {
+class Polygon : public Shape {
 public:
 	/**
 	 * A pointer to a Polygon
 	 */
-	typedef std::shared_ptr<Polygon>       Ptr;
+	typedef std::shared_ptr<Polygon> Ptr;
 
 	/**
 	 * Public constructor
 	 *
 	 * @param vertices the vertices of the polygon
 	 */
-	Polygon(const Vector2dList & vertices);
+	Polygon(const Vector2dList &vertices);
 
 	virtual ~Polygon();
 
@@ -304,14 +309,14 @@ public:
 	 *
 	 * @returns a Vector2dList of the polygon vertices
 	 */
-	const Vector2dList & Vertices() const;
+	const Vector2dList &Vertices() const;
 
 	/**
 	 * Sets the Polygon's vertices
 	 *
 	 * @param vertices a Vector2dList of the polygon vertices
 	 */
-	void SetVertices(const Vector2dList & vertices);
+	void SetVertices(const Vector2dList &vertices);
 
 	/**
 	 * Gets the number of vertices in the polygon
@@ -328,7 +333,7 @@ public:
 	 * @return a const reference to the wanted vertex
 	 * @throws std::out_of_range if i is >= Size().
 	 */
-	const Eigen::Vector2d & Vertex(size_t i) const;
+	const Eigen::Vector2d &Vertex(size_t i) const;
 
 	/**
 	 * Sets a Polygon vertex
@@ -337,7 +342,7 @@ public:
 	 * @param v the new value for the vertex
 	 * @throws std::out_of_range if i is >= Size().
 	 */
-	void SetVertex(size_t i, const Eigen::Vector2d & v);
+	void SetVertex(size_t i, const Eigen::Vector2d &v);
 
 	/**
 	 * Deletes a Polygon vertex
@@ -347,8 +352,10 @@ public:
 	 */
 	void DeleteVertex(size_t i);
 
+	std::string Format() const override;
+
 	/** \cond PRIVATE */
-	bool Contains(const Eigen::Vector2d & point) const override;
+	bool Contains(const Eigen::Vector2d &point) const override;
 
 	AABB ComputeAABB() const override;
 

--- a/src/fort/myrmidon/Space.cpp
+++ b/src/fort/myrmidon/Space.cpp
@@ -59,7 +59,12 @@ std::pair<std::string,uint64_t> Space::LocateMovieFrame(const Time & time) const
 	throw std::out_of_range(oss.str());
 }
 
-
+std::string Space::Format() const {
+	std::ostringstream oss;
+	oss << "Space{ID:" << ID() << ",Name:'" << Name()
+	    << "',Zones:" << Zones().size() << "}";
+	return oss.str();
+}
 
 } // namespace myrmidon
 } // namespace fort

--- a/src/fort/myrmidon/Space.hpp
+++ b/src/fort/myrmidon/Space.hpp
@@ -47,14 +47,14 @@ public:
 	 *
 	 * @return the Space name
 	 */
-	const std::string & Name() const;
+	const std::string &Name() const;
 
 	/**
 	 * Sets the Space name
 	 *
 	 * @param name the wanted name
 	 */
-	void SetName(const std::string & name);
+	void SetName(const std::string &name);
 
 	/**
 	 * Creates a new Zone in this Space
@@ -63,14 +63,15 @@ public:
 	 *
 	 * @return the newly created Zone
 	 */
-	Zone::Ptr CreateZone(const std::string & name);
+	Zone::Ptr CreateZone(const std::string &name);
 
 	/**
 	 * Deletes a Zone in this Space.
 	 *
 	 * @param zoneID the ZoneID of the Zone to delete.
 	 *
-	 * @throws std::out_of_range if zoneID is not the ID of a Zone owned by this Space.
+	 * @throws std::out_of_range if zoneID is not the ID of a Zone owned by this
+	 * Space.
 	 */
 	void DeleteZone(ZoneID zoneID);
 
@@ -79,7 +80,7 @@ public:
 	 *
 	 * @return a map of Zone::ByID of all Zone in this Space.
 	 */
-	const ZoneByID & Zones() const;
+	const ZoneByID &Zones() const;
 
 	/**
 	 * Locates a movie file and frame number
@@ -92,10 +93,12 @@ public:
 	 * @throws std::out_of_range if a movie frame for the specified
 	 *         Time could not be found.
 	 */
-	std::pair<std::string,uint64_t> LocateMovieFrame(const Time & time) const;
+	std::pair<std::string, uint64_t> LocateMovieFrame(const Time &time) const;
 
 	// needed as SpaceHandle is opaque and we store a unique_ptr.
 	~Space();
+
+	std::string Format() const;
 
 private:
 	friend class ExperimentHandle;
@@ -107,7 +110,7 @@ private:
 	// accessed from <Experiment>.
 	Space(std::unique_ptr<SpaceHandle> handle);
 
-	Space & operator=(const Space &) = delete;
+	Space &operator=(const Space &) = delete;
 
 	Space(const Space &) = delete;
 

--- a/src/fort/myrmidon/TrackingSolver.cpp
+++ b/src/fort/myrmidon/TrackingSolver.cpp
@@ -1,31 +1,33 @@
 #include "TrackingSolver.hpp"
+#include "fort/myrmidon/types/IdentifiedFrame.hpp"
 
 #include <fort/myrmidon/priv/TrackingSolver.hpp>
-
 
 namespace fort {
 namespace myrmidon {
 
+TrackingSolver::TrackingSolver(const PPtr &pTracker)
+    : d_p(pTracker) {}
 
-TrackingSolver::TrackingSolver(const PPtr & pTracker)
-	: d_p(pTracker) {
+void TrackingSolver::IdentifyFrame(
+    IdentifiedFrame                  &identified,
+    const fort::hermes::FrameReadout &frame,
+    SpaceID                           spaceID,
+    size_t                            zoneDepth,
+    ZonePriority                      zoneOrder
+) const {
+	d_p->IdentifyFrame(identified, frame, spaceID, zoneDepth, zoneOrder);
 }
 
-void TrackingSolver::IdentifyFrame(IdentifiedFrame & identified,
-                                                   const fort::hermes::FrameReadout & frame,
-                                                   SpaceID spaceID) const {
-	d_p->IdentifyFrame(identified,frame,spaceID);
+void TrackingSolver::CollideFrame(
+    IdentifiedFrame &identified, CollisionFrame &collision
+) const {
+	d_p->CollideFrame(collision, identified);
 }
 
-void TrackingSolver::CollideFrame(IdentifiedFrame & identified,
-                                  CollisionFrame & collision) const {
-	d_p->CollideFrame(collision,identified);
+AntID TrackingSolver::IdentifyAnt(TagID tagID, const Time &time) {
+	return d_p->IdentifyTag(tagID, time);
 }
-
-AntID TrackingSolver::IdentifyAnt(TagID tagID, const Time & time) {
-	return d_p->IdentifyTag(tagID,time);
-}
-
 
 } // namespace myrmidon
 } // namespace fort

--- a/src/fort/myrmidon/TrackingSolver.hpp
+++ b/src/fort/myrmidon/TrackingSolver.hpp
@@ -30,7 +30,7 @@ class TrackingSolver;
  */
 
 class TrackingSolver {
-public :
+public:
 	typedef std::unique_ptr<TrackingSolver> Ptr;
 	/**
 	 *  Identifies a single ant
@@ -41,7 +41,7 @@ public :
 	 * @return returns the AntID of the Ant tagID is identifying at
 	 *         time, or 0 if there is no matching identification.
 	 */
-	AntID IdentifyAnt(TagID tagID, const Time & time);
+	AntID IdentifyAnt(TagID tagID, const Time &time);
 
 	/**
 	 * Identifies Ants from a `fort::hermes::FrameReadout`
@@ -52,9 +52,13 @@ public :
 	 * @param spaceID the spaceID the frame correspond to
 	 *
 	 */
-	void IdentifyFrame(IdentifiedFrame & identified,
-	                   const fort::hermes::FrameReadout & frame,
-	                   SpaceID spaceID) const;
+	void IdentifyFrame(
+	    IdentifiedFrame                  &identified,
+	    const fort::hermes::FrameReadout &frame,
+	    SpaceID                           spaceID,
+	    size_t                            zoneDepth,
+	    ZonePriority                      zoneOrder
+	) const;
 
 	/**
 	 * Collides Ants from an IdentifiedFrame
@@ -69,8 +73,8 @@ public :
 	 * identified.
 	 *
 	 */
-	void CollideFrame(IdentifiedFrame & identified,
-	                  CollisionFrame & collision) const;
+	void
+	CollideFrame(IdentifiedFrame &identified, CollisionFrame &collision) const;
 
 private:
 	friend class Experiment;
@@ -82,15 +86,13 @@ private:
 	//
 	// User cannot create a TrackingSolver directly. They must use
 	// <Experiment::CompileTrackingSolver>.
-	TrackingSolver(const PPtr & pTracker);
+	TrackingSolver(const PPtr &pTracker);
 
-	TrackingSolver & operator=(const TrackingSolver &) = delete;
-	TrackingSolver(const TrackingSolver &) = delete;
+	TrackingSolver &operator=(const TrackingSolver &) = delete;
+	TrackingSolver(const TrackingSolver &)            = delete;
 
 	PPtr d_p;
 };
-
-
 
 } //namespace myrmidon
 } //namespace fort

--- a/src/fort/myrmidon/TrackingSolverUTest.cpp
+++ b/src/fort/myrmidon/TrackingSolverUTest.cpp
@@ -44,7 +44,14 @@ TEST_F(PublicTrackingSolverUTest, CanIdentifyAnts) {
 TEST_F(PublicTrackingSolverUTest, CanIdentifyAndCollideFrames) {
 	IdentifiedFrame identified;
 	CollisionFrame  collision;
-	EXPECT_NO_THROW(solver->IdentifyFrame(identified, readout, 1));
+	EXPECT_NO_THROW(solver->IdentifyFrame(
+	    identified,
+	    readout,
+	    1,
+	    0,
+	    ZonePriority::PREDECENCE_LOWER
+	));
+	EXPECT_EQ(identified.Positions.cols(), 4);
 	EXPECT_EQ(identified.Positions.rows(), 3);
 	EXPECT_NO_THROW(solver->CollideFrame(identified, collision));
 	EXPECT_TRUE(collision.Collisions.empty());

--- a/src/fort/myrmidon/TypesUTest.cpp
+++ b/src/fort/myrmidon/TypesUTest.cpp
@@ -27,7 +27,8 @@ TEST_F(PublicTypesUTest, IdentifiedFrameMethods) {
 
 	auto [antID, position, zoneID] = data->At(0);
 	EXPECT_EQ(antID, 1);
-	EXPECT_EQ(zoneID, 0);
+
+	EXPECT_EQ(zoneID, Eigen::VectorXd{{0.0}});
 }
 
 TEST_F(PublicTypesUTest, AntTrajectoryMethods) {

--- a/src/fort/myrmidon/Zone.cpp
+++ b/src/fort/myrmidon/Zone.cpp
@@ -1,61 +1,57 @@
 #include "Zone.hpp"
 
 #include <fort/myrmidon/Shapes.hpp>
+#include <sstream>
 
-#include "handle/ZoneHandle.hpp"
 #include "handle/ZoneDefinitionHandle.hpp"
+#include "handle/ZoneHandle.hpp"
 
 #include "priv/Zone.hpp"
 
 namespace fort {
 namespace myrmidon {
 
-
-
 Zone::Zone(std::unique_ptr<ZoneHandle> handle)
-	: d_p(std::move(handle)) {
-}
+    : d_p(std::move(handle)) {}
 
 Zone::~Zone() = default;
 
 ZoneDefinition::ZoneDefinition(std::unique_ptr<ZoneDefinitionHandle> handle)
-	: d_p(std::move(handle)) {
-}
+    : d_p(std::move(handle)) {}
 
 ZoneDefinition::~ZoneDefinition() = default;
 
-const Shape::List & ZoneDefinition::Shapes() const {
+const Shape::List &ZoneDefinition::Shapes() const {
 	return d_p->Get().Shapes();
 }
 
-void ZoneDefinition::SetShapes(const Shape::List & shapes) {
+void ZoneDefinition::SetShapes(const Shape::List &shapes) {
 	d_p->Get().SetShapes(shapes);
 }
 
-
-const Time & ZoneDefinition::Start() const {
+const Time &ZoneDefinition::Start() const {
 	return d_p->Get().Start();
 }
 
-const Time & ZoneDefinition::End() const {
+const Time &ZoneDefinition::End() const {
 	return d_p->Get().End();
 }
 
-void ZoneDefinition::SetStart(const Time & start) {
+void ZoneDefinition::SetStart(const Time &start) {
 	d_p->Get().SetStart(start);
 }
 
-void ZoneDefinition::SetEnd(const Time & end) {
+void ZoneDefinition::SetEnd(const Time &end) {
 	d_p->Get().SetEnd(end);
 }
 
-ZoneDefinition::Ptr Zone::AddDefinition(const Shape::List & shapes,
-                                        const Time & start,
-                                        const Time & end) {
-	return d_p->AddDefinition(shapes,start,end);
+ZoneDefinition::Ptr Zone::AddDefinition(
+    const Shape::List &shapes, const Time &start, const Time &end
+) {
+	return d_p->AddDefinition(shapes, start, end);
 }
 
-const ZoneDefinitionList & Zone::Definitions() const {
+const ZoneDefinitionList &Zone::Definitions() const {
 	return d_p->Definitions();
 }
 
@@ -63,11 +59,11 @@ void Zone::DeleteDefinition(size_t index) {
 	d_p->DeleteDefinition(index);
 }
 
-const std::string & Zone::Name() const {
+const std::string &Zone::Name() const {
 	return d_p->Get().Name();
 }
 
-void Zone::SetName(const std::string & name) {
+void Zone::SetName(const std::string &name) {
 	d_p->Get().SetName(name);
 }
 
@@ -75,7 +71,12 @@ ZoneID Zone::ID() const {
 	return d_p->Get().ID();
 }
 
-
+std::string Zone::Format() const {
+	std::ostringstream oss;
+	oss << "Zone{ID:" << ID() << ",Name:'" << Name()
+	    << "',Definitions:" << Definitions().size() << "}";
+	return oss.str();
+}
 
 } // namespace myrmidon
 } // namespace fort

--- a/src/fort/myrmidon/Zone.hpp
+++ b/src/fort/myrmidon/Zone.hpp
@@ -34,14 +34,14 @@ public:
 	 * @return a list of Shape that define the Shape of the Zone for
 	 *         [Start();End()[
 	 */
-	const Shape::List & Shapes() const;
+	const Shape::List &Shapes() const;
 
 	/**
 	 * Sets the Shapes of this ZoneDefinition
 	 *
 	 * @param shapes a union of Shape defining the Zone shapes.
 	 */
-	void SetShapes(const Shape::List & shapes);
+	void SetShapes(const Shape::List &shapes);
 
 	/**
 	 * Gets the first valid time of the ZoneDefinition
@@ -49,7 +49,7 @@ public:
 	 * @return the first valid Time of this definition. It can be
 	 *         Time::SinceEver().
 	 */
-	const Time & Start() const;
+	const Time &Start() const;
 
 	/**
 	 * Gets the first invalid time of the ZoneDefinition
@@ -57,7 +57,7 @@ public:
 	 * @return the first invalid Time of this definition. It can be
 	 *         Time::Forever().
 	 */
-	const Time & End() const;
+	const Time &End() const;
 
 	/**
 	 * Sets the first valid time of the ZoneDefinition
@@ -65,7 +65,7 @@ public:
 	 * @param start the first valid Time of this definition. It can be
 	 *        Time::SinceEver().
 	 */
-	void SetStart(const Time & start);
+	void SetStart(const Time &start);
 
 	/**
 	 * Sets the first invalid time of the ZoneDefinition
@@ -73,10 +73,10 @@ public:
 	 * @param end the first invalid Time of this definition. It can be
 	 *        Time::Forever().
 	 */
-	void SetEnd(const Time & end);
+	void SetEnd(const Time &end);
 
-	ZoneDefinition & operator=( const ZoneDefinition &) = delete;
-	ZoneDefinition(const ZoneDefinition & ) = delete;
+	ZoneDefinition &operator=(const ZoneDefinition &) = delete;
+	ZoneDefinition(const ZoneDefinition &)            = delete;
 
 	~ZoneDefinition();
 
@@ -92,7 +92,6 @@ private:
 
 	std::unique_ptr<ZoneDefinitionHandle> d_p;
 };
-
 
 /**
  * A tracking region where collisions/interactions are computed.
@@ -151,9 +150,9 @@ public:
 	 *         resulting definition overlap in time with another
 	 *         ZoneDefinition for this Zone.
 	 */
-	ZoneDefinition::Ptr AddDefinition(const Shape::List & shapes,
-	                                  const Time & start,
-	                                  const Time & end);
+	ZoneDefinition::Ptr           AddDefinition(
+	              const Shape::List &shapes, const Time &start, const Time &end
+	          );
 
 	/**
 	 * Gets the Zone's ZoneDefinition
@@ -161,7 +160,7 @@ public:
 	 * @return a ZoneDefinition::List of ZoneDefinition for this Zone
 	 *
 	 */
-	const ZoneDefinitionList & Definitions() const;
+	const ZoneDefinitionList &Definitions() const;
 
 	/**
 	 * Removes a ZoneDefinition
@@ -177,14 +176,14 @@ public:
 	 *
 	 * @return the Zone name
 	 */
-	const std::string & Name() const;
+	const std::string &Name() const;
 
 	/**
 	 * Gets the Zone name
 	 *
 	 * @param name the wanted Name()
 	 */
-	void SetName(const std::string & name);
+	void SetName(const std::string &name);
 
 	/**
 	 * Gets the Zone ID
@@ -193,6 +192,7 @@ public:
 	 */
 	ZoneID ID() const;
 
+	std::string Format() const;
 
 	~Zone();
 
@@ -206,12 +206,11 @@ private:
 	// accessed from <Space>.
 	Zone(std::unique_ptr<ZoneHandle> handle);
 
-	Zone & operator=( const Zone &) = delete;
-	Zone(const Zone &) = delete;
+	Zone &operator=(const Zone &) = delete;
+	Zone(const Zone &)            = delete;
 
 	std::unique_ptr<ZoneHandle> d_p;
 };
-
 
 } // namespace myrmidon
 } // namespace fort

--- a/src/fort/myrmidon/priv/CollisionSolver.cpp
+++ b/src/fort/myrmidon/priv/CollisionSolver.cpp
@@ -1,177 +1,260 @@
 #include "CollisionSolver.hpp"
 
-#include "Space.hpp"
-#include <fort/myrmidon/Shapes.hpp>
 #include "AntShapeType.hpp"
 #include "KDTree.hpp"
+#include "Space.hpp"
+#include "fort/myrmidon/priv/Zone.hpp"
+#include "fort/myrmidon/types/IdentifiedFrame.hpp"
+#include "fort/time/Time.hpp"
+#include <fort/myrmidon/Shapes.hpp>
+#include <stdexcept>
 
 namespace fort {
 namespace myrmidon {
 namespace priv {
 
-CollisionSolver::CollisionSolver(const SpaceByID & spaces,
-                                 const AntByID & ants,
-                                 bool ignoreZones)
-	: d_ignoreZones(ignoreZones) {
+CollisionSolver::CollisionSolver(
+    const SpaceByID &spaces, const AntByID &ants, bool ignoreZones
+)
+    : d_ignoreZones(ignoreZones) {
 
 	// Deep copy ant shape data.
-	for ( const auto & [aID,ant] : ants ) {
-		d_antGeometries.insert(std::make_pair(aID,ant->Capsules()));
+	for (const auto &[aID, ant] : ants) {
+		d_antGeometries.insert(std::make_pair(aID, ant->Capsules()));
 	}
 
-	for ( const auto & [spaceID,space] : spaces ) {
-		auto res = d_spaceDefinitions.insert(std::make_pair(spaceID,ZoneGeometriesByTime()));
-		d_zoneIDs.insert(std::make_pair(spaceID,std::vector<ZoneID>()));
-		auto & definitions = res.first->second;
-		for ( const auto & [zID,zone] : space->Zones() ) {
+	// compiles Zoner per time.
+
+	typedef TimeMap<ZoneID, ZoneGeometry::ConstPtr> ZoneGeometriesByTime;
+	for (const auto &[spaceID, space] : spaces) {
+		std::set<Time> times = {fort::Time::SinceEver()};
+		d_zoneIDs.insert(std::make_pair(spaceID, std::vector<ZoneID>()));
+		// we compile all definitions change over time for a space.
+		ZoneGeometriesByTime geometries;
+		for (const auto &[zID, zone] : space->Zones()) {
+
 			d_zoneIDs.at(spaceID).push_back(zID);
-			for ( const auto & definition : zone->Definitions() ) {
-				definitions.InsertOrAssign(zID,
-				                           std::make_shared<ZoneGeometry>(definition->Shapes()),
-				                           definition->Start());
-				if ( definition->End().IsForever() == false) {
-					definitions.InsertOrAssign(zID,
-					                           std::make_shared<ZoneGeometry>(Shape::List()),
-					                           definition->End());
+			for (const auto &definition : zone->Definitions()) {
+				geometries.InsertOrAssign(
+				    zID,
+				    std::make_shared<ZoneGeometry>(definition->Shapes()),
+				    definition->Start()
+				);
+				times.insert(definition->Start());
+				if (definition->End().IsForever() == false) {
+					geometries.InsertOrAssign(
+					    zID,
+					    std::make_shared<ZoneGeometry>(Shape::List()),
+					    definition->End()
+					);
+					times.insert(definition->End());
 				}
+			}
+		}
+
+		// In this space, we collect all zones ant put it in the right zoner.
+		for (const auto &time : times) {
+			std::vector<std::pair<ZoneID, Zone::Geometry::ConstPtr>>
+			    currentGeometries;
+			for (const auto &zID : d_zoneIDs.at(spaceID)) {
+				try {
+					currentGeometries.push_back({zID, geometries.At(zID, time)}
+					);
+				} catch (const std::exception &e) {
+					continue;
+				}
+			}
+
+			d_spaceZoners.InsertOrAssign(
+			    spaceID,
+			    std::make_shared<AntZoner>(currentGeometries),
+			    time
+			);
+		}
+	}
+}
+
+void CollisionSolver::ComputeCollisions(
+    CollisionFrame &collision, IdentifiedFrame &frame
+) const {
+	if (d_spaceZoners.Count(frame.Space) == 0) {
+		throw std::invalid_argument(
+		    "Unknown SpaceID " + std::to_string(frame.Space) +
+		    " in IdentifiedFrame"
+		);
+	}
+
+	LocatedAnts locatedAnts;
+	LocateAnts(locatedAnts, frame);
+	collision.FrameTime = frame.FrameTime;
+	collision.Space     = frame.Space;
+	collision.Collisions.clear();
+	for (const auto &[zID, ants] : locatedAnts) {
+		ComputeCollisions(collision.Collisions, ants, zID);
+	}
+}
+
+AntZoner::ConstPtr CollisionSolver::ZonerFor(const IdentifiedFrame &frame
+) const {
+	try {
+		return d_spaceZoners.At(frame.Space, frame.FrameTime);
+	} catch (const std::out_of_range &e) {
+		throw std::invalid_argument(
+		    "Unknown SpaceID " + std::to_string(frame.Space) +
+		    " in collision solver: " + std::string(e.what()) +
+		    d_spaceZoners.DebugString()
+		);
+	}
+}
+
+AntZoner::AntZoner(const ZoneGeometries &zoneGeometries)
+    : d_zoneGeometries(zoneGeometries) {}
+
+void AntZoner::LocateAnts(
+    IdentifiedFrame::PositionMatrix &ants, ZonePriority priority
+) const {
+	if (ants.cols() <= 4) {
+		return;
+	}
+	size_t zoneDepth = ants.cols() - 4;
+	switch (priority) {
+	case ZonePriority::PREDECENCE_LOWER:
+		locateAntsLower(ants);
+		break;
+	case ZonePriority::PREDECENCE_HIGHER:
+		locateAntsHigher(ants);
+		break;
+	}
+}
+
+void AntZoner::locateAntsLower(IdentifiedFrame::PositionMatrix &ants) const {
+	size_t zoneDepth = ants.cols() - 4;
+	for (size_t i = 0; i < ants.rows(); ++i) {
+		size_t matched{0};
+		for (auto iter = d_zoneGeometries.begin();
+		     iter != d_zoneGeometries.end();
+		     ++iter) {
+			if (iter->second->Contains(ants.block<1, 2>(i, 1).transpose()) ==
+			    false) {
+				continue;
+			}
+			ants(i, 4 + matched) = iter->first;
+			if (++matched >= zoneDepth) {
+				break;
 			}
 		}
 	}
 }
 
-
-void CollisionSolver::ComputeCollisions(CollisionFrame & collision,
-                                        IdentifiedFrame & frame) const {
-	LocatedAnts locatedAnts;
-	LocateAnts(locatedAnts,frame);
-	collision.FrameTime = frame.FrameTime;
-	collision.Space = frame.Space;
-	collision.Collisions.clear();
-	for ( const auto & [zID,ants] : locatedAnts ) {
-		ComputeCollisions(collision.Collisions,ants,zID);
-	}
-}
-
-
-AntZoner::ConstPtr CollisionSolver::ZonerFor(const IdentifiedFrame & frame) const {
-	if ( d_spaceDefinitions.count(frame.Space) == 0) {
-		throw std::invalid_argument("Unknown SpaceID " + std::to_string(frame.Space) + " in IdentifiedFrame");
-	}
-	const auto & allDefinitions = d_spaceDefinitions.at(frame.Space);
-
-	// first we build geometries for the right time;
-	std::vector<std::pair<ZoneID,Zone::Geometry::ConstPtr> > currentGeometries;
-	for ( const auto & zID : d_zoneIDs.at(frame.Space) ) {
-		try {
-			auto geometry = allDefinitions.At(zID,frame.FrameTime);
-			currentGeometries.push_back(std::make_pair(zID,geometry));
-		} catch ( const std::exception & e ) {
-			continue;
+void AntZoner::locateAntsHigher(IdentifiedFrame::PositionMatrix &ants) const {
+	size_t zoneDepth = ants.cols() - 4;
+	for (size_t i = 0; i < ants.rows(); ++i) {
+		size_t matched{0};
+		for (auto iter = d_zoneGeometries.rbegin();
+		     iter != d_zoneGeometries.rend();
+		     ++iter) {
+			if (iter->second->Contains(ants.block<1, 2>(i, 1).transpose()) ==
+			    false) {
+				continue;
+			}
+			ants(i, 4 + matched) = iter->first;
+			if (++matched >= zoneDepth) {
+				break;
+			}
 		}
 	}
-	return std::make_shared<AntZoner>(currentGeometries);
 }
 
+void CollisionSolver::LocateAnts(
+    LocatedAnts &locatedAnts, IdentifiedFrame &frame
+) const {
 
-AntZoner::AntZoner(const ZoneGeometries & zoneGeometries)
-	: d_zoneGeometries(zoneGeometries) {
-}
-
-ZoneID AntZoner::LocateAnt(PositionedAntRef ant) const {
-	auto fi =  std::find_if(d_zoneGeometries.begin(),
-	                        d_zoneGeometries.end(),
-	                        [&ant](const std::pair<ZoneID,Zone::Geometry::ConstPtr> & iter ) -> bool {
-		                        return iter.second->Contains(ant.block<1,2>(0,1).transpose());
-	                        });
-	if ( fi == d_zoneGeometries.end() ) {
-		return 0;
-	}
-	ant(0,4) = fi->first;
-	return fi->first;
-}
-
-
-void CollisionSolver::LocateAnts(LocatedAnts & locatedAnts,
-                                 IdentifiedFrame & frame) const {
-
-	auto zoner = ZonerFor(frame);
-
+	size_t zoneDepth = frame.Positions.cols() - 4;
 	// now for each geometry. we test if the ants is in the zone
-	for ( size_t i = 0; i < frame.Positions.rows(); ++i ) {
-		ZoneID zoneID = zoner->LocateAnt(frame.Positions.row(i));
-		locatedAnts[d_ignoreZones == true ? 0 : zoneID].push_back(frame.Positions.row(i));
+	for (size_t i = 0; i < frame.Positions.rows(); ++i) {
+		size_t islandIndex = 0;
+		if (d_ignoreZones == false && zoneDepth > 0) {
+			islandIndex = frame.Positions(i, 4);
+		}
+		locatedAnts[islandIndex].push_back(frame.Positions.row(i));
 	}
 }
 
+void CollisionSolver::ComputeCollisions(
+    std::vector<Collision>                   &result,
+    const std::vector<PositionedAntConstRef> &ants,
+    ZoneID                                    zoneID
+) const {
 
-void CollisionSolver::ComputeCollisions(std::vector<Collision> &  result,
-                                        const std::vector<PositionedAntConstRef> & ants,
-                                        ZoneID zoneID) const {
-
-	//first-pass we compute possible interactions
-	struct AntTypedCapsule  {
+	// first-pass we compute possible interactions
+	struct AntTypedCapsule {
 		Capsule          C;
 		AntID            ID;
 		AntShapeType::ID TypeID;
-		inline bool operator<( const AntTypedCapsule & other ) {
+
+		inline bool operator<(const AntTypedCapsule &other) {
 			return ID < other.ID;
 		}
-		inline bool operator>( const AntTypedCapsule & other ) {
+
+		inline bool operator>(const AntTypedCapsule &other) {
 			return ID > other.ID;
 		}
-		inline bool operator!=( const AntTypedCapsule & other ) {
+
+		inline bool operator!=(const AntTypedCapsule &other) {
 			return ID != other.ID;
 		}
 	};
-	typedef KDTree<AntTypedCapsule,double,2> KDT;
+
+	typedef KDTree<AntTypedCapsule, double, 2> KDT;
 
 	std::vector<KDT::Element> nodes;
 
-	for ( const auto & ant : ants) {
-		AntID antID = ant(0,0);
-		auto fiGeom = d_antGeometries.find(antID);
-		if ( fiGeom == d_antGeometries.end() ) {
+	for (const auto &ant : ants) {
+		AntID antID  = ant(0, 0);
+		auto  fiGeom = d_antGeometries.find(antID);
+		if (fiGeom == d_antGeometries.end()) {
 			continue;
 		}
-		Isometry2Dd antToOrig(ant(0,3),ant.block<1,2>(0,1).transpose());
+		Isometry2Dd antToOrig(ant(0, 3), ant.block<1, 2>(0, 1).transpose());
 
-		for ( const auto & [typeID,c] : fiGeom->second ) {
-			auto data =
-				AntTypedCapsule { .C = c->Transform(antToOrig),
-				                  .ID = antID,
-				                  .TypeID = typeID,
+		for (const auto &[typeID, c] : fiGeom->second) {
+			auto data = AntTypedCapsule{
+			    .C      = c->Transform(antToOrig),
+			    .ID     = antID,
+			    .TypeID = typeID,
 			};
-			nodes.push_back({.Object = data, .Volume = data.C.ComputeAABB() });
+			nodes.push_back({.Object = data, .Volume = data.C.ComputeAABB()});
 		}
 	}
-	auto kdt = KDT::Build(nodes.begin(),nodes.end(),-1);
-	std::list<std::pair<AntTypedCapsule,AntTypedCapsule>> possibleCollisions;
-	auto inserter = std::inserter(possibleCollisions,possibleCollisions.begin());
+	auto kdt = KDT::Build(nodes.begin(), nodes.end(), -1);
+	std::list<std::pair<AntTypedCapsule, AntTypedCapsule>> possibleCollisions;
+	auto                                                   inserter =
+	    std::inserter(possibleCollisions, possibleCollisions.begin());
 	kdt->ComputeCollisions(inserter);
 
 	// now do the actual collisions
-	std::map<InteractionID,std::set<std::pair<uint32_t,uint32_t>>> res;
-	for ( const auto & coarse : possibleCollisions ) {
-		if ( coarse.first.C.Intersects(coarse.second.C) == true ) {
-			InteractionID ID = std::make_pair(coarse.first.ID,coarse.second.ID);
-			auto type = std::make_pair(coarse.first.TypeID,coarse.second.TypeID);
+	std::map<InteractionID, std::set<std::pair<uint32_t, uint32_t>>> res;
+	for (const auto &coarse : possibleCollisions) {
+		if (coarse.first.C.Intersects(coarse.second.C) == true) {
+			InteractionID ID =
+			    std::make_pair(coarse.first.ID, coarse.second.ID);
+			auto type =
+			    std::make_pair(coarse.first.TypeID, coarse.second.TypeID);
 			res[ID].insert(type);
 		}
 	}
 	result.reserve(result.size() + res.size());
-	for ( const auto & [ID,interactionSet] : res ) {
-		InteractionTypes interactions(interactionSet.size(),2);
-		size_t i = 0;
-		for ( const auto & t : interactionSet ) {
-			interactions(i,0) = t.first;
-			interactions(i,1) = t.second;
+	for (const auto &[ID, interactionSet] : res) {
+		InteractionTypes interactions(interactionSet.size(), 2);
+		size_t           i = 0;
+		for (const auto &t : interactionSet) {
+			interactions(i, 0) = t.first;
+			interactions(i, 1) = t.second;
 			++i;
 		}
-		result.push_back(Collision{ID,interactions,zoneID});
+		result.push_back(Collision{ID, interactions, zoneID});
 	}
-
 }
-
 
 } // namespace priv
 } // namespace myrmidon

--- a/src/fort/myrmidon/priv/CollisionSolver.hpp
+++ b/src/fort/myrmidon/priv/CollisionSolver.hpp
@@ -18,51 +18,58 @@ class AntZoner {
 public:
 	typedef std::shared_ptr<AntZoner>       Ptr;
 	typedef std::shared_ptr<const AntZoner> ConstPtr;
-	typedef std::vector<std::pair<ZoneID,Zone::Geometry::ConstPtr> > ZoneGeometries;
+	typedef std::vector<std::pair<ZoneID, Zone::Geometry::ConstPtr>>
+	    ZoneGeometries;
 
-	AntZoner(const ZoneGeometries & zoneGeometries);
+	AntZoner(const ZoneGeometries &zoneGeometries);
 
-	ZoneID LocateAnt(PositionedAntRef antRow) const;
+	void LocateAnts(
+	    IdentifiedFrame::PositionMatrix &ants, ZonePriority priority
+	) const;
+
 private:
 	ZoneGeometries d_zoneGeometries;
-};
 
+	void locateAntsHigher(IdentifiedFrame::PositionMatrix &ants) const;
+
+	void locateAntsLower(IdentifiedFrame::PositionMatrix &ants) const;
+};
 
 class CollisionSolver {
 public:
 	typedef std::shared_ptr<CollisionSolver>       Ptr;
 	typedef std::shared_ptr<const CollisionSolver> ConstPtr;
 
-	CollisionSolver(const SpaceByID & spaces,
-	                const AntByID & ants,
-	                bool ignoreZones);
+	CollisionSolver(
+	    const SpaceByID &spaces, const AntByID &ants, bool ignoreZones
+	);
 
-	AntZoner::ConstPtr ZonerFor(const IdentifiedFrame & frame) const;
+	AntZoner::ConstPtr ZonerFor(const IdentifiedFrame &frame) const;
 
-	void ComputeCollisions(CollisionFrame & collision,
-	                       IdentifiedFrame & frame) const;
+	void
+	ComputeCollisions(CollisionFrame &collision, IdentifiedFrame &frame) const;
 
 private:
-	typedef DenseMap<AntID,TypedCapsuleList>                                AntGeometriesByID;
-	typedef TimeMap<ZoneID,ZoneGeometry::ConstPtr>                          ZoneGeometriesByTime;
-	typedef DenseMap<SpaceID,ZoneGeometriesByTime>                          GeometriesBySpaceID;
-	typedef DenseMap<SpaceID,std::vector<ZoneID>>                           ZoneIDsBySpaceID;
-	typedef std::unordered_map<ZoneID,std::vector<PositionedAntConstRef>>   LocatedAnts;
+	typedef DenseMap<AntID, TypedCapsuleList>      AntGeometriesByID;
+	typedef TimeMap<SpaceID, AntZoner::ConstPtr>   AntZonerByTime;
+	typedef DenseMap<SpaceID, AntZonerByTime>      AntZonerBySpaceID;
+	typedef DenseMap<SpaceID, std::vector<ZoneID>> ZoneIDsBySpaceID;
+	typedef std::unordered_map<ZoneID, std::vector<PositionedAntConstRef>>
+	    LocatedAnts;
 
-	void LocateAnts(LocatedAnts & locatedAnts,
-	                IdentifiedFrame & frame) const;
+	void LocateAnts(LocatedAnts &locatedAnts, IdentifiedFrame &frame) const;
 
-	void ComputeCollisions(std::vector<Collision> &  result,
-	                       const std::vector<PositionedAntConstRef> & positions,
-	                       ZoneID zoneID) const;
+	void ComputeCollisions(
+	    std::vector<Collision>                   &result,
+	    const std::vector<PositionedAntConstRef> &positions,
+	    ZoneID                                    zoneID
+	) const;
 
-	AntGeometriesByID    d_antGeometries;
-	GeometriesBySpaceID  d_spaceDefinitions;
-	ZoneIDsBySpaceID     d_zoneIDs;
-	bool                 d_ignoreZones;
-
+	AntGeometriesByID d_antGeometries;
+	AntZonerByTime    d_spaceZoners;
+	ZoneIDsBySpaceID  d_zoneIDs;
+	bool              d_ignoreZones;
 };
-
 
 } // namespace priv
 } // namespace myrmidon

--- a/src/fort/myrmidon/priv/Query.cpp
+++ b/src/fort/myrmidon/priv/Query.cpp
@@ -167,7 +167,7 @@ void Query::IdentifyFrames(
 	    {
 	        .Start                 = args.Start,
 	        .End                   = args.End,
-	        .Localize              = args.ComputeZones,
+	        .ZoneDepth             = args.ZoneDepth,
 	        .Collide               = false,
 	        .CollisionsIgnoreZones = false,
 	        .Progress              = args.Progress.get(),
@@ -190,7 +190,7 @@ void Query::CollideFrames(
 	    {
 	        .Start                 = args.Start,
 	        .End                   = args.End,
-	        .Localize              = false,
+	        .ZoneDepth             = args.ZoneDepth,
 	        .Collide               = true,
 	        .CollisionsIgnoreZones = args.CollisionsIgnoreZones,
 	        .Progress              = args.Progress.get(),
@@ -227,7 +227,7 @@ void Query::ComputeTrajectories(
 	    {
 	        .Start                 = args.Start,
 	        .End                   = args.End,
-	        .Localize              = args.ComputeZones,
+	        .ZoneDepth             = args.ZoneDepth,
 	        .Collide               = false,
 	        .CollisionsIgnoreZones = false,
 	        .Progress              = args.Progress.get(),
@@ -269,7 +269,7 @@ void Query::ComputeAntInteractions(
 	    {
 	        .Start                 = args.Start,
 	        .End                   = args.End,
-	        .Localize              = false,
+	        .ZoneDepth             = args.ZoneDepth,
 	        .Collide               = true,
 	        .CollisionsIgnoreZones = args.CollisionsIgnoreZones,
 	        .Progress              = args.Progress.get(),

--- a/src/fort/myrmidon/priv/QueryRunner.hpp
+++ b/src/fort/myrmidon/priv/QueryRunner.hpp
@@ -10,6 +10,7 @@
 #include <fort/myrmidon/types/Typedefs.hpp>
 
 #include "ForwardDeclaration.hpp"
+#include "fort/myrmidon/types/IdentifiedFrame.hpp"
 
 namespace fort {
 namespace myrmidon {
@@ -28,7 +29,8 @@ public:
 	struct Args {
 		Time                  Start;
 		Time                  End;
-		bool                  Localize;
+		size_t                ZoneDepth;
+		ZonePriority          ZoneOrder;
 		bool                  Collide;
 		bool                  CollisionsIgnoreZones;
 		TimeProgressReporter *Progress;

--- a/src/fort/myrmidon/priv/RawFrame.hpp
+++ b/src/fort/myrmidon/priv/RawFrame.hpp
@@ -39,9 +39,9 @@ public:
 	// Any error on the frame
 	fort::hermes::FrameReadout_Error Error() const;
 
-	const std::string & URI() const override;
+	const std::string &URI() const override;
 
-	const FrameReference & Frame() const;
+	const FrameReference &Frame() const;
 
 	// The width of the frame
 	int32_t Width() const;
@@ -49,28 +49,35 @@ public:
 	// The height of the frame
 	int32_t Height() const;
 
-	const ::google::protobuf::RepeatedPtrField<::fort::hermes::Tag> & Tags() const;
+	const ::google::protobuf::RepeatedPtrField<::fort::hermes::Tag> &
+	Tags() const;
 
-	void IdentifyFrom(IdentifiedFrame & frame,const IdentifierIF & identifier,SpaceID spaceID) const;
+	void IdentifyFrom(
+	    IdentifiedFrame    &frame,
+	    const IdentifierIF &identifier,
+	    SpaceID             spaceID,
+	    size_t              zoneDepth
+	) const;
 
-	static RawFrame::ConstPtr Create(const std::string & parentURI,
-	                                 fort::hermes::FrameReadout & pb,
-	                                 Time::MonoclockID clockID);
+	static RawFrame::ConstPtr Create(
+	    const std::string          &parentURI,
+	    fort::hermes::FrameReadout &pb,
+	    Time::MonoclockID           clockID
+	);
 
 private:
-
-	RawFrame(const std::string & parentURI,
-	         fort::hermes::FrameReadout & pb,
-	         Time::MonoclockID clockID);
-
+	RawFrame(
+	    const std::string          &parentURI,
+	    fort::hermes::FrameReadout &pb,
+	    Time::MonoclockID           clockID
+	);
 
 	fort::hermes::FrameReadout_Error                      d_error;
-	int32_t                                               d_width,d_height;
+	int32_t                                               d_width, d_height;
 	google::protobuf::RepeatedPtrField<fort::hermes::Tag> d_tags;
 	FrameReference                                        d_frame;
 	std::string                                           d_URI;
 };
-
-}
+} // namespace priv
 }
 }

--- a/src/fort/myrmidon/priv/TimeMap.hpp
+++ b/src/fort/myrmidon/priv/TimeMap.hpp
@@ -1,51 +1,57 @@
 #pragma once
 
-
 #include <fort/time/Time.hpp>
 
-#include <map>
-#include <unordered_map>
 #include <limits>
+#include <map>
+#include <sstream>
+#include <unordered_map>
 
 namespace fort {
 namespace myrmidon {
 namespace priv {
 
-template <typename T,typename U>
-class TimeMap {
+template <typename T, typename U> class TimeMap {
 public:
-
-	inline void Insert(const T & key, const U & value , const Time & time) {
-		if ( time.IsForever() == true ) {
+	inline void Insert(const T &key, const U &value, const Time &time) {
+		if (time.IsForever() == true) {
 			throw std::invalid_argument("time value cannot be +∞");
 		}
 		auto fi = d_map.find(key);
-		if ( fi == d_map.end() ) {
-			auto res = d_map.insert(std::make_pair(key,ValuesByTime()));
-			fi = res.first;
+		if (fi == d_map.end()) {
+			auto res = d_map.insert(std::make_pair(key, ValuesByTime()));
+			fi       = res.first;
 		}
-		fi->second.insert(std::make_pair(time,value));
+		fi->second.insert(std::make_pair(time, value));
 	}
 
-	inline void InsertOrAssign(const T & key, const U & value , const Time & time) {
-		if ( time.IsForever() == true ) {
+	inline void InsertOrAssign(const T &key, const U &value, const Time &time) {
+		if (time.IsForever() == true) {
 			throw std::invalid_argument("time value cannot be +∞");
 		}
 		auto fi = d_map.find(key);
-		if ( fi == d_map.end() ) {
-			auto res = d_map.insert(std::make_pair(key,ValuesByTime()));
-			fi = res.first;
+		if (fi == d_map.end()) {
+			auto res = d_map.insert(std::make_pair(key, ValuesByTime()));
+			fi       = res.first;
 		}
-		fi->second.insert_or_assign(time,value);
+		fi->second.insert_or_assign(time, value);
 	}
 
-	inline const U & At(const T & key, const Time & t) const {
+	inline size_t Count(const T &key) const noexcept {
+		try {
+			return d_map.at(key).size();
+		} catch (const std::exception &) {
+			return 0;
+		}
+	}
+
+	inline const U &At(const T &key, const Time &t) const {
 		auto fi = d_map.find(key);
-		if ( fi == d_map.end() || fi->second.empty() ) {
+		if (fi == d_map.end() || fi->second.empty()) {
 			throw std::out_of_range("Invalid key");
 		}
 		auto ti = fi->second.upper_bound(t);
-		if ( ti == fi->second.begin() ) {
+		if (ti == fi->second.begin()) {
 			throw std::out_of_range("Invalid time");
 		}
 		return std::prev(ti)->second;
@@ -55,15 +61,27 @@ public:
 		d_map.clear();
 	}
 
-	const std::map<Time,U> & Values(const T & key) const {
+	const std::map<Time, U> &Values(const T &key) const {
 		return d_map.at(key);
 	}
 
+	std::string DebugString() const {
+		std::ostringstream oss;
+		oss << "keys: " << d_map.size() << std::endl;
+		for (const auto &[key, valueByTime] : d_map) {
+			for (const auto &[time, value] : valueByTime) {
+				oss << " + [" << key << "]{" << time << "}" << value
+				    << std::endl;
+			}
+		}
+
+		return oss.str();
+	}
+
 private:
-	typedef std::map<Time,U> ValuesByTime;
+	typedef std::map<Time, U> ValuesByTime;
 
-	std::unordered_map<T,ValuesByTime> d_map;
-
+	std::unordered_map<T, ValuesByTime> d_map;
 };
 
 } // namespace priv

--- a/src/fort/myrmidon/priv/TrackingSolver.cpp
+++ b/src/fort/myrmidon/priv/TrackingSolver.cpp
@@ -1,58 +1,73 @@
 #include "TrackingSolver.hpp"
 #include "CollisionSolver.hpp"
 #include "Identifier.hpp"
+#include "fort/myrmidon/types/IdentifiedFrame.hpp"
 
 namespace fort {
 namespace myrmidon {
 namespace priv {
 
-
-TrackingSolver::TrackingSolver(const std::shared_ptr<const Identifier> & identifier,
-                               const CollisionSolver::ConstPtr & solver)
-	: d_solver(solver) {
+TrackingSolver::TrackingSolver(
+    const std::shared_ptr<const Identifier> &identifier,
+    const CollisionSolver::ConstPtr         &solver
+)
+    : d_solver(solver) {
 	d_identifier = Identifier::Compile(identifier);
 }
 
-void TrackingSolver::IdentifyFrame(IdentifiedFrame & identified,
-                                   const fort::hermes::FrameReadout & frame,
-                                   SpaceID spaceID) const {
+void TrackingSolver::IdentifyFrame(
+    IdentifiedFrame                  &identified,
+    const fort::hermes::FrameReadout &frame,
+    SpaceID                           spaceID,
+    size_t                            zoneDepth,
+    ZonePriority                      zoneOrder
+) const {
 
-	identified.Space = spaceID;
+	identified.Space     = spaceID;
 	identified.FrameTime = Time::FromTimestamp(frame.time());
-	identified.Width = frame.width();
-	identified.Height = frame.height();
-	identified.Positions.resize(frame.tags().size(),5);
+	identified.Width     = frame.width();
+	identified.Height    = frame.height();
+	identified.Positions.resize(frame.tags().size(), 5);
 	size_t index = 0;
-	for ( const auto & t : frame.tags() ) {
-		auto identification = d_identifier->Identify(t.id(),identified.FrameTime);
-		if ( !identification == true ) {
+	for (const auto &t : frame.tags()) {
+		auto identification =
+		    d_identifier->Identify(t.id(), identified.FrameTime);
+		if (!identification == true) {
 			continue;
 		}
-		identified.Positions(index,0) = identification->Target()->AntID();
-		identified.Positions(index,4) = 0;
-		identification->ComputePositionFromTag(identified.Positions(index,1),
-		                                       identified.Positions(index,2),
-		                                       identified.Positions(index,3),
-		                                       Eigen::Vector2d(t.x(),t.y()),
-		                                       t.theta());
+		identified.Positions(index, 0) = identification->Target()->AntID();
+		if (zoneDepth > 0) {
+			identified.Positions.block(index, 4, 1, zoneDepth).setConstant(0.0);
+		}
+		identification->ComputePositionFromTag(
+		    identified.Positions(index, 1),
+		    identified.Positions(index, 2),
+		    identified.Positions(index, 3),
+		    Eigen::Vector2d(t.x(), t.y()),
+		    t.theta()
+		);
 		++index;
 	}
-	identified.Positions.conservativeResize(index,5);
+	identified.Positions.conservativeResize(index, 4 + zoneDepth);
+	if (zoneDepth > 0) {
+		auto zoner = d_solver->ZonerFor(identified);
+		zoner->LocateAnts(identified.Positions, zoneOrder);
+	}
 }
 
-void TrackingSolver::CollideFrame(CollisionFrame & collision,
-                                  IdentifiedFrame & identified) const {
-	d_solver->ComputeCollisions(collision,identified);
+void TrackingSolver::CollideFrame(
+    CollisionFrame &collision, IdentifiedFrame &identified
+) const {
+	d_solver->ComputeCollisions(collision, identified);
 }
 
-AntID TrackingSolver::IdentifyTag(TagID tagID, const Time & time) {
-	auto identification = d_identifier->Identify(tagID,time);
-	if ( ! identification ) {
+AntID TrackingSolver::IdentifyTag(TagID tagID, const Time &time) {
+	auto identification = d_identifier->Identify(tagID, time);
+	if (!identification) {
 		return 0;
 	}
 	return identification->Target()->AntID();
 }
-
 
 } // namespace priv
 } // namespace myrmidon

--- a/src/fort/myrmidon/priv/TrackingSolver.hpp
+++ b/src/fort/myrmidon/priv/TrackingSolver.hpp
@@ -13,28 +13,33 @@ namespace myrmidon {
 namespace priv {
 
 class TrackingSolver {
-public :
+public:
 	typedef std::shared_ptr<const TrackingSolver> ConstPtr;
 
-	TrackingSolver(const IdentifierConstPtr & identifier,
-	               const CollisionSolverConstPtr & solver);
+	TrackingSolver(
+	    const IdentifierConstPtr      &identifier,
+	    const CollisionSolverConstPtr &solver
+	);
 
 	// Identifies a single tag
 	// @tagID the TagID to identify
 	// @time the time to consider to identify the tag
 	//
 	// @return 0 if the tag is not idnetified, or the corresponding ID
-	AntID IdentifyTag(TagID tagID, const Time & time);
-
+	AntID IdentifyTag(TagID tagID, const Time &time);
 
 	// Identifies Ants from a `fort::hermes::FrameReadout`
 	// @frame the `fort::hermes::FrameReadout` to identify
 	// @spaceID the spaceID the frame correspond to
 	//
 	// @return an <IdentifiedFrame> with all identified ant (without zone)
-	void IdentifyFrame(IdentifiedFrame & identified,
-	                   const fort::hermes::FrameReadout & frame,
-	                   SpaceID spaceID) const;
+	void IdentifyFrame(
+	    IdentifiedFrame                  &identified,
+	    const fort::hermes::FrameReadout &frame,
+	    SpaceID                           spaceID,
+	    size_t                            zoneDepth,
+	    ZonePriority                      zoneOrder
+	) const;
 
 	// Collides Ants from an IdentifiedFrame
 	// @identified the <IdentifiedFrame> with the ant position data.
@@ -43,12 +48,11 @@ public :
 	// modified to contains for each Ant its current zone.
 	//
 	// @return a <CollisionFrame> with all current Ant collisions.
-	void CollideFrame(CollisionFrame & c,
-	                  IdentifiedFrame & identified) const;
-private :
-	IdentifierIFConstPtr              d_identifier;
-	CollisionSolverConstPtr           d_solver;
+	void CollideFrame(CollisionFrame &c, IdentifiedFrame &identified) const;
 
+private:
+	IdentifierIFConstPtr    d_identifier;
+	CollisionSolverConstPtr d_solver;
 };
 
 } // namespace priv

--- a/src/fort/myrmidon/priv/fort/myrmidon/types/IdentifiedFrame.hpp
+++ b/src/fort/myrmidon/priv/fort/myrmidon/types/IdentifiedFrame.hpp
@@ -1,1 +1,0 @@
-#include "EigenRefs.hpp"

--- a/src/fort/myrmidon/types/IdentifiedFrame.cpp
+++ b/src/fort/myrmidon/types/IdentifiedFrame.cpp
@@ -7,14 +7,24 @@ bool IdentifiedFrame::Contains(uint64_t antID) const {
 	return (Positions.array().col(0) == double(antID)).any();
 }
 
-std::tuple<AntID,const Eigen::Ref<const Eigen::Vector3d>,ZoneID> IdentifiedFrame::At(size_t index) const {
-	if ( index > Positions.rows() ) {
-		throw std::out_of_range(std::to_string(index) + " is out of range [0," + std::to_string(Positions.rows()) + "[");
+std::tuple<
+    AntID,
+    const Eigen::Ref<const Eigen::Vector3d>,
+    const Eigen::Ref<const Eigen::VectorXd>>
+IdentifiedFrame::At(size_t index) const {
+	if (index > Positions.rows()) {
+		throw std::out_of_range(
+		    std::to_string(index) + " is out of range [0," +
+		    std::to_string(Positions.rows()) + "["
+		);
 	}
-	AntID antID = AntID(Positions(index,0));
-	ZoneID zoneID = ZoneID(Positions(index,4));
-	Eigen::Ref<const Eigen::Vector3d> position = Positions.block<1,3>(index,1).transpose();
-	return std::make_tuple(antID,position,zoneID);
+
+	AntID                             antID = AntID(Positions(index, 0));
+	Eigen::Ref<const Eigen::Vector3d> position =
+	    Positions.block<1, 3>(index, 1).transpose();
+	Eigen::Ref<const Eigen::VectorXd> zones =
+	    Positions.block(index, 4, 1, Positions.cols() - 4).transpose();
+	return std::make_tuple(antID, position, zones);
 }
 
 } // namespace myrmidon

--- a/src/fort/myrmidon/types/IdentifiedFrame.hpp
+++ b/src/fort/myrmidon/types/IdentifiedFrame.hpp
@@ -30,38 +30,42 @@ struct IdentifiedFrame {
 	/**
 	 * A pointer to an IdentifiedFrame
 	 */
-	typedef std::shared_ptr<IdentifiedFrame>       Ptr;
+	typedef std::shared_ptr<IdentifiedFrame> Ptr;
 
 	/**
 	 * A Matrix of ant position.
 	 *
 	 * * The first column is the AntID
-	 * * The second and third columns are the x,y position in the original video frame.
+	 * * The second and third columns are the x,y position in the original video
+	 * frame.
 	 * * The fourth column is the ant angle
-	 * * The fifth column is the ant current zone or 0 if in no zone or zones aren't computed.
+	 * * The fifth column and further (if presents) are the ant current zones
+	 *   IDs or 0 if not in any zones.
 	 */
-	typedef Eigen::Matrix<double,Eigen::Dynamic,5,Eigen::RowMajor> PositionMatrix;
+	typedef Eigen::
+	    Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+	        PositionMatrix;
 
 	/**
 	 * The acquisition Time of this frame
 	 */
-	Time              FrameTime;
+	Time           FrameTime;
 	/**
 	 *  The Space this frame belongs to.
 	 */
-	SpaceID           Space;
+	SpaceID        Space;
 	/**
 	 *  The original height of the video frame
 	 */
-	size_t            Height;
+	size_t         Height;
 	/**
 	 *  The original width of the video frame
 	 */
-	size_t            Width;
+	size_t         Width;
 	/**
 	 * The position of each ant in that frame
 	 */
-	PositionMatrix    Positions;
+	PositionMatrix Positions;
 
 	/**
 	 * Tests if the frame contains an Ant
@@ -75,14 +79,23 @@ struct IdentifiedFrame {
 	 * Extract Ant position data at a given row
 	 * @param index the row we want to extract data from
 	 *
-	 * @return the AntID, x,y,angle position and the ZoneID for the
+	 * @return the AntID, x,y,angle position and the zones IDs for the
 	 *         Ant at index.
 	 */
-	std::tuple<AntID,const Eigen::Ref<const Eigen::Vector3d>,ZoneID> At(size_t index) const;
+	std::tuple<
+	    AntID,
+	    const Eigen::Ref<const Eigen::Vector3d>,
+	    const Eigen::Ref<const Eigen::VectorXd>>
+	At(size_t index) const;
 
 	// type traits;
 	typedef timed_data data_category;
 };
 
-}
-}
+enum class ZonePriority {
+	PREDECENCE_LOWER  = 0,
+	PREDECENCE_HIGHER = 1,
+};
+
+} // namespace myrmidon
+} // namespace fort

--- a/src/fort/studio/widget/vectorgraphics/Handle.cpp
+++ b/src/fort/studio/widget/vectorgraphics/Handle.cpp
@@ -1,21 +1,20 @@
 #include "Handle.hpp"
 
-
-#include <QPen>
 #include "VectorialScene.hpp"
+#include <QPen>
 
-const qreal Handle::SIZE = 9;
-const QColor Handle::COLOR = QColor(127,127,127,255);
-const QColor Handle::SELECTED_COLOR = QColor(200,200,200,255);
-
+const qreal  Handle::SIZE           = 9;
+const QColor Handle::COLOR          = QColor(180, 180, 180, 255);
+const QColor Handle::SELECTED_COLOR = QColor(200, 200, 200, 255);
 
 QRectF Handle::build() {
-	return QRectF(-d_factor * SIZE/2,
-	              -d_factor * SIZE/2,
-	              d_factor * SIZE,
-	              d_factor * SIZE);
+	return QRectF(
+	    -d_factor * SIZE / 2,
+	    -d_factor * SIZE / 2,
+	    d_factor * SIZE,
+	    d_factor * SIZE
+	);
 }
-
 
 Handle::Handle(MovedCallback onMove,
                ReleasedCallback onRelease,
@@ -54,8 +53,20 @@ void Handle::addToScene(QGraphicsScene * scene) {
 	}
 }
 
-void Handle::mouseMoveEvent(QGraphicsSceneMouseEvent * e) {
+void Handle::mouseMoveEvent(QGraphicsSceneMouseEvent *e) {
 	QGraphicsItemGroup::mouseMoveEvent(e);
+	if (x() < 0) {
+		setPos(0, y());
+	} else if (x() > scene()->width()) {
+		setPos(scene()->width(), y());
+	}
+
+	if (y() < 0) {
+		setPos(x(), 0);
+	} else if (y() > scene()->height()) {
+		setPos(x(), scene()->height());
+	}
+
 	d_onMove();
 }
 


### PR DESCRIPTION
Many `fort::myrmidon` object were binding a `__str__` method, but not an equivalent `__repr__` method. It was a poor interaction with ipython (jupyter notebooks)